### PR TITLE
fix: use simplified category names for layer-1 classification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ data/**
 
 # data
 *.json
+.worktrees/

--- a/main.py
+++ b/main.py
@@ -682,9 +682,13 @@ class PrimeVulLayer1Pipeline:
                         print(f"        🎯 解析结果: '{predicted_category}'")
 
                     if predicted_category is None:
-                        predicted_category = "Other"
+                        response_lower = response.lower()
+                        if "benign" in response_lower or "no vuln" in response_lower:
+                            predicted_category = "Benign"
+                        else:
+                            predicted_category = "Other"
                         if batch_idx == 0 and idx < 3:
-                            print(f"        ⚠️ 无法解析，回退为: 'Other'")
+                            print(f"        ⚠️ 无法解析，回退为: '{predicted_category}'")
 
                     predictions.append(predicted_category)
 

--- a/main.py
+++ b/main.py
@@ -26,15 +26,11 @@ sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 from evoprompt.data.sampler import sample_primevul_1percent
 from evoprompt.data.dataset import PrimevulDataset
-from evoprompt.data.cwe_layer1 import (
-    CWE_ID_PATTERN,
-    LAYER1_ALIAS_MAP,
-    LAYER1_CLASS_LABELS,
-    LAYER1_CATEGORY_DESCRIPTIONS_BLOCK,
-    LAYER1_DESCENDANT_TO_ROOT,
-    LAYER1_SUBCATEGORY_REFERENCE,
-    canonicalize_layer1_category,
-    map_cwe_to_layer1,
+from evoprompt.data.cwe_categories import (
+    CWE_MAJOR_CATEGORIES,
+    canonicalize_category,
+    map_cwe_to_major,
+    CATEGORY_DESCRIPTIONS_BLOCK,
 )
 from evoprompt.llm.client import create_default_client, create_meta_prompt_client
 from evoprompt.algorithms.base import Individual, Population
@@ -307,10 +303,9 @@ class PromptEvolver:
         self.config = config
         self.evolution_history = []
         self.builder = StructuredPromptBuilder(
-            LAYER1_CLASS_LABELS,
+            CWE_MAJOR_CATEGORIES,
             self.DEFAULT_GUIDANCE,
-            subcategory_reference=LAYER1_SUBCATEGORY_REFERENCE,
-            category_descriptions=LAYER1_CATEGORY_DESCRIPTIONS_BLOCK,
+            category_descriptions=CATEGORY_DESCRIPTIONS_BLOCK,
         )
 
     def evolve_with_feedback(
@@ -653,7 +648,7 @@ class PrimeVulLayer1Pipeline:
             cwe_codes = sample.metadata.get("cwe", [])
 
             if ground_truth_binary == 1 and cwe_codes:
-                ground_truth_category = map_cwe_to_layer1(cwe_codes)
+                ground_truth_category = map_cwe_to_major(cwe_codes)
             else:
                 ground_truth_category = "Benign"
 
@@ -679,7 +674,7 @@ class PrimeVulLayer1Pipeline:
                 if response == "error":
                     predictions.append("Other")
                 else:
-                    predicted_category = canonicalize_layer1_category(response)
+                    predicted_category = canonicalize_category(response)
 
                     # 调试：打印前几个响应
                     if batch_idx == 0 and idx < 3:
@@ -687,31 +682,9 @@ class PrimeVulLayer1Pipeline:
                         print(f"        🎯 解析结果: '{predicted_category}'")
 
                     if predicted_category is None:
-                        response_lower = response.lower()
-                        for key, mapped_label in LAYER1_ALIAS_MAP.items():
-                            if len(key) <= 4:
-                                continue
-                            if key in response_lower:
-                                predicted_category = mapped_label
-                                break
-
-                        if predicted_category is None:
-                            match = CWE_ID_PATTERN.search(response_lower)
-                            if match:
-                                candidate_label = LAYER1_DESCENDANT_TO_ROOT.get(match.group().upper())
-                                if candidate_label:
-                                    predicted_category = candidate_label
-
-                        if predicted_category is None:
-                            if "benign" in response_lower:
-                                predicted_category = "Benign"
-                            elif "unknown" in response_lower or "other" in response_lower:
-                                predicted_category = "Other"
-                            else:
-                                predicted_category = "Other"
-
+                        predicted_category = "Other"
                         if batch_idx == 0 and idx < 3:
-                            print(f"        ⚠️ 使用层级映射回退: '{predicted_category}'")
+                            print(f"        ⚠️ 无法解析，回退为: 'Other'")
 
                     predictions.append(predicted_category)
 
@@ -818,7 +791,7 @@ class PrimeVulLayer1Pipeline:
         report = classification_report(
             all_ground_truths,
             all_predictions,
-            labels=LAYER1_CLASS_LABELS,
+            labels=CWE_MAJOR_CATEGORIES,
             output_dict=True,
             zero_division=0
         )
@@ -827,7 +800,7 @@ class PrimeVulLayer1Pipeline:
         cm = confusion_matrix(
             all_ground_truths,
             all_predictions,
-            labels=LAYER1_CLASS_LABELS
+            labels=CWE_MAJOR_CATEGORIES
         )
 
         return {
@@ -1122,7 +1095,7 @@ class PrimeVulLayer1Pipeline:
             f.write(f"{'Category':<25} {'Precision':>10} {'Recall':>10} {'F1-Score':>10} {'Support':>10}\n")
             f.write(f"{'-'*80}\n")
 
-            for category in LAYER1_CLASS_LABELS:
+            for category in CWE_MAJOR_CATEGORIES:
                 if category in report:
                     metrics = report[category]
                     f.write(f"{category:<25} {metrics['precision']:>10.4f} {metrics['recall']:>10.4f} "
@@ -1142,7 +1115,7 @@ class PrimeVulLayer1Pipeline:
         confusion_file = self.exp_dir / "confusion_matrix.json"
         with open(confusion_file, "w", encoding="utf-8") as f:
             json.dump({
-                "labels": LAYER1_CLASS_LABELS,
+                "labels": CWE_MAJOR_CATEGORIES,
                 "matrix": best_result["confusion_matrix"]
             }, f, indent=2, ensure_ascii=False)
         print(f"  ✓ {confusion_file}")
@@ -1177,7 +1150,7 @@ class PrimeVulLayer1Pipeline:
         print(f"{'Category':<25} {'Precision':>10} {'Recall':>10} {'F1-Score':>10} {'Support':>10}")
         print(f"{'-'*80}")
 
-        for category in LAYER1_CLASS_LABELS:
+        for category in CWE_MAJOR_CATEGORIES:
             if category in report:
                 metrics = report[category]
                 print(f"{category:<25} {metrics['precision']:>10.4f} {metrics['recall']:>10.4f} "

--- a/main.py
+++ b/main.py
@@ -683,10 +683,17 @@ class PrimeVulLayer1Pipeline:
 
                     if predicted_category is None:
                         response_lower = response.lower()
-                        if "benign" in response_lower or "no vuln" in response_lower:
-                            predicted_category = "Benign"
-                        else:
-                            predicted_category = "Other"
+                        # Try CWE-ID extraction as fallback
+                        predicted_category = canonicalize_category(response_lower)
+                        # Broader benign detection
+                        if predicted_category is None:
+                            if any(p in response_lower for p in (
+                                "benign", "no vuln", "no security issue",
+                                "not vulnerable", "safe", "secure code",
+                            )):
+                                predicted_category = "Benign"
+                            else:
+                                predicted_category = "Other"
                         if batch_idx == 0 and idx < 3:
                             print(f"        ⚠️ 无法解析，回退为: '{predicted_category}'")
 

--- a/src/evoprompt/data/cwe_categories.py
+++ b/src/evoprompt/data/cwe_categories.py
@@ -73,6 +73,20 @@ _CWE_ID_TO_MAJOR = {
     200: "Information Exposure",  # Information Exposure
 }
 
+# Human-readable descriptions for each major category
+CATEGORY_DESCRIPTIONS_BLOCK = "\n".join([
+    "- Buffer Errors: Out-of-bounds read/write, stack/heap buffer overflow, incorrect buffer size calculation (CWE-119, CWE-120, CWE-125, CWE-787)",
+    "- Injection: SQL injection, OS command injection, cross-site scripting, code injection (CWE-74, CWE-77, CWE-78, CWE-79, CWE-89)",
+    "- Memory Management: Use-after-free, double free, memory leak, missing release of resources (CWE-416, CWE-415, CWE-401)",
+    "- Pointer Dereference: NULL pointer dereference, invalid pointer access (CWE-476)",
+    "- Integer Errors: Integer overflow/underflow, wraparound, incorrect type conversion (CWE-190, CWE-191)",
+    "- Concurrency Issues: Race conditions, improper synchronization, TOCTOU (CWE-362)",
+    "- Path Traversal: Directory traversal, improper pathname restriction (CWE-22)",
+    "- Cryptography Issues: Weak algorithms, missing encryption, hardcoded keys, insufficient randomness (CWE-310, CWE-327, CWE-330)",
+    "- Information Exposure: Sensitive data disclosure via logs, error messages, or improper access control (CWE-200)",
+    "- Other: Vulnerability patterns not covered by the categories above",
+])
+
 _CWE_ID_REGEX = re.compile(r"CWE-(\d+)")
 
 

--- a/src/evoprompt/data/cwe_categories.py
+++ b/src/evoprompt/data/cwe_categories.py
@@ -90,13 +90,13 @@ _CATEGORY_DESCRIPTIONS: dict = {
 }
 
 # Verify every non-Benign category in CWE_MAJOR_CATEGORIES has a description.
+# Uses assert so it fires during development/testing but not with python -O.
 _described = set(_CATEGORY_DESCRIPTIONS.keys())
 _expected = {c for c in CWE_MAJOR_CATEGORIES if c != "Benign"}
-if _described != _expected:
-    raise ValueError(
-        f"_CATEGORY_DESCRIPTIONS out of sync with CWE_MAJOR_CATEGORIES. "
-        f"Missing: {_expected - _described}, Extra: {_described - _expected}"
-    )
+assert _described == _expected, (
+    f"_CATEGORY_DESCRIPTIONS out of sync with CWE_MAJOR_CATEGORIES. "
+    f"Missing: {_expected - _described}, Extra: {_described - _expected}"
+)
 
 CATEGORY_DESCRIPTIONS_BLOCK = "\n".join(
     f"- {cat}: {_CATEGORY_DESCRIPTIONS[cat]}"

--- a/src/evoprompt/data/cwe_categories.py
+++ b/src/evoprompt/data/cwe_categories.py
@@ -73,19 +73,36 @@ _CWE_ID_TO_MAJOR = {
     200: "Information Exposure",  # Information Exposure
 }
 
-# Human-readable descriptions for each major category
-CATEGORY_DESCRIPTIONS_BLOCK = "\n".join([
-    "- Buffer Errors: Out-of-bounds read/write, stack/heap buffer overflow, incorrect buffer size calculation (CWE-119, CWE-120, CWE-125, CWE-787)",
-    "- Injection: SQL injection, OS command injection, cross-site scripting, code injection (CWE-74, CWE-77, CWE-78, CWE-79, CWE-89)",
-    "- Memory Management: Use-after-free, double free, memory leak, missing release of resources (CWE-416, CWE-415, CWE-401)",
-    "- Pointer Dereference: NULL pointer dereference, invalid pointer access (CWE-476)",
-    "- Integer Errors: Integer overflow/underflow, wraparound, incorrect type conversion (CWE-190, CWE-191)",
-    "- Concurrency Issues: Race conditions, improper synchronization, TOCTOU (CWE-362)",
-    "- Path Traversal: Directory traversal, improper pathname restriction (CWE-22)",
-    "- Cryptography Issues: Weak algorithms, missing encryption, hardcoded keys, insufficient randomness (CWE-310, CWE-327, CWE-330)",
-    "- Information Exposure: Sensitive data disclosure via logs, error messages, or improper access control (CWE-200)",
-    "- Other: Vulnerability patterns not covered by the categories above",
-])
+# Human-readable descriptions keyed by category name to stay in sync with
+# CWE_MAJOR_CATEGORIES.  Only vulnerability categories need descriptions;
+# "Benign" is self-explanatory and excluded from the prompt description block.
+_CATEGORY_DESCRIPTIONS: dict = {
+    "Buffer Errors": "Out-of-bounds read/write, stack/heap buffer overflow, incorrect buffer size calculation (CWE-119, CWE-120, CWE-125, CWE-787)",
+    "Injection": "SQL injection, OS command injection, cross-site scripting, code injection (CWE-74, CWE-77, CWE-78, CWE-79, CWE-89)",
+    "Memory Management": "Use-after-free, double free, memory leak, missing release of resources (CWE-416, CWE-415, CWE-401)",
+    "Pointer Dereference": "NULL pointer dereference, invalid pointer access (CWE-476)",
+    "Integer Errors": "Integer overflow/underflow, wraparound, incorrect type conversion (CWE-190, CWE-191)",
+    "Concurrency Issues": "Race conditions, improper synchronization, TOCTOU (CWE-362)",
+    "Path Traversal": "Directory traversal, improper pathname restriction (CWE-22)",
+    "Cryptography Issues": "Weak algorithms, missing encryption, hardcoded keys, insufficient randomness (CWE-310, CWE-327, CWE-330)",
+    "Information Exposure": "Sensitive data disclosure via logs, error messages, or improper access control (CWE-200)",
+    "Other": "Vulnerability patterns not covered by the categories above",
+}
+
+# Verify every non-Benign category in CWE_MAJOR_CATEGORIES has a description.
+_described = set(_CATEGORY_DESCRIPTIONS.keys())
+_expected = {c for c in CWE_MAJOR_CATEGORIES if c != "Benign"}
+if _described != _expected:
+    raise ValueError(
+        f"_CATEGORY_DESCRIPTIONS out of sync with CWE_MAJOR_CATEGORIES. "
+        f"Missing: {_expected - _described}, Extra: {_described - _expected}"
+    )
+
+CATEGORY_DESCRIPTIONS_BLOCK = "\n".join(
+    f"- {cat}: {_CATEGORY_DESCRIPTIONS[cat]}"
+    for cat in CWE_MAJOR_CATEGORIES
+    if cat in _CATEGORY_DESCRIPTIONS
+)
 
 _CWE_ID_REGEX = re.compile(r"CWE-(\d+)")
 

--- a/src/evoprompt/data/sampler.py
+++ b/src/evoprompt/data/sampler.py
@@ -35,21 +35,8 @@ class BalancedSampler:
         if balance_mode == "target":
             return str(target_int)
 
-        if balance_mode == "major":
-            if target_int == 0:
-                return "Benign"
-
-            cwe_codes = item.get("cwe", [])
-            if isinstance(cwe_codes, str):
-                cwe_codes = [cwe_codes] if cwe_codes else []
-            elif not isinstance(cwe_codes, list):
-                cwe_codes = []
-
-            major = map_cwe_to_major(cwe_codes) if cwe_codes else "Other"
-            return major or "Other"
-
-        if balance_mode == "layer1":
-            # Use simplified category names (same as "major" mode)
+        if balance_mode in ("major", "layer1"):
+            # "layer1" is an alias for "major" — both use simplified category names
             if target_int == 0:
                 return "Benign"
 

--- a/src/evoprompt/data/sampler.py
+++ b/src/evoprompt/data/sampler.py
@@ -49,6 +49,7 @@ class BalancedSampler:
             return major or "Other"
 
         if balance_mode == "layer1":
+            # Use simplified category names (same as "major" mode)
             if target_int == 0:
                 return "Benign"
 
@@ -58,8 +59,8 @@ class BalancedSampler:
             elif not isinstance(cwe_codes, list):
                 cwe_codes = []
 
-            layer1 = map_cwe_to_layer1(cwe_codes) if cwe_codes else "Other"
-            return layer1 or "Other"
+            major = map_cwe_to_major(cwe_codes) if cwe_codes else "Other"
+            return major or "Other"
 
         raise ValueError(f"Unsupported balance_mode: {balance_mode}")
 


### PR DESCRIPTION
## Summary

- Replace abstract CWE Research View root labels (e.g., `CWE-664 Improper Control of a Resource Through its Lifetime`) with simplified category names (e.g., `Buffer Errors`, `Memory Management`) for Layer-1 classification
- The old labels lumped multiple distinct vulnerability types into single abstract buckets, hurting LLM discrimination (e.g., buffer errors + memory management + pointer dereference all mapped to CWE-664)
- Simplify prediction parsing by removing redundant fallback logic — `canonicalize_category()` already handles CWE IDs, keywords, and synonyms
- Ensure sampler `balance_mode="layer1"` uses the same simplified names as the evaluation pipeline

## Test plan

- [x] All three changed files compile (`py_compile`)
- [x] Verified `canonicalize_category()` correctly maps: exact names, CWE IDs, keyword phrases
- [x] Verified `map_cwe_to_major()` maps all 10 vulnerability CWE families correctly
- [ ] Run smoke test with `--balance-mode layer1 --fitness-metric macro_f1` to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

新功能：
- 为在提示与评估中使用的每个简化 CWE 主要类别引入可读性更高的人类描述。

错误修复：
- 当 `balance_mode="layer1"` 或 `"major"` 时，确保真实标签和采样器标签都使用 CWE 主要类别。
- 对无法解析的模型预测结果进行确定性的回退：对明显良性的响应回退为 `"Benign"`，否则回退为 `"Other"`。

改进：
- 在提示构造、指标报告和混淆矩阵输出中，用简化的 CWE 主要类别替换旧版的 layer-1 类别标签及元数据。
- 通过使用单一函数来规范模型预测和 CWE 标识符，实现分类标准化的集中管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

新功能：
- 为在提示与评估中使用的每个简化 CWE 主要类别引入可读性更高的人类描述。

错误修复：
- 当 `balance_mode="layer1"` 或 `"major"` 时，确保真实标签和采样器标签都使用 CWE 主要类别。
- 对无法解析的模型预测结果进行确定性的回退：对明显良性的响应回退为 `"Benign"`，否则回退为 `"Other"`。

改进：
- 在提示构造、指标报告和混淆矩阵输出中，用简化的 CWE 主要类别替换旧版的 layer-1 类别标签及元数据。
- 通过使用单一函数来规范模型预测和 CWE 标识符，实现分类标准化的集中管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

新功能：
- 为在提示与评估中使用的每个简化 CWE 主要类别引入可读性更高的人类描述。

错误修复：
- 当 `balance_mode="layer1"` 或 `"major"` 时，确保真实标签和采样器标签都使用 CWE 主要类别。
- 对无法解析的模型预测结果进行确定性的回退：对明显良性的响应回退为 `"Benign"`，否则回退为 `"Other"`。

改进：
- 在提示构造、指标报告和混淆矩阵输出中，用简化的 CWE 主要类别替换旧版的 layer-1 类别标签及元数据。
- 通过使用单一函数来规范模型预测和 CWE 标识符，实现分类标准化的集中管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

新功能：
- 为在提示与评估中使用的每个简化 CWE 主要类别引入可读性更高的人类描述。

错误修复：
- 当 `balance_mode="layer1"` 或 `"major"` 时，确保真实标签和采样器标签都使用 CWE 主要类别。
- 对无法解析的模型预测结果进行确定性的回退：对明显良性的响应回退为 `"Benign"`，否则回退为 `"Other"`。

改进：
- 在提示构造、指标报告和混淆矩阵输出中，用简化的 CWE 主要类别替换旧版的 layer-1 类别标签及元数据。
- 通过使用单一函数来规范模型预测和 CWE 标识符，实现分类标准化的集中管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

</details>

</details>

</details>

新功能：
- 为用于提示词和评估的简化 CWE 主要类别引入更易读的人类可读描述。

错误修复：
- 修复真实标签与采样器标签的映射问题，使第 1 层平衡和评估使用一致的 CWE 主要类别，而不是旧的第 1 层标签。
- 确保无法解析的模型预测能够以确定性的方式回退到 “Other” 类别。

改进：
- 在提示构造、指标报告和混淆矩阵输出中，用 CWE 主要类别替换旧的第 1 层类别标签和子类别元数据。
- 通过将 CWE ID 和别名的解析委托给单一规范化函数，简化类别规范化逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

新功能：
- 为在提示与评估中使用的每个简化 CWE 主要类别引入可读性更高的人类描述。

错误修复：
- 当 `balance_mode="layer1"` 或 `"major"` 时，确保真实标签和采样器标签都使用 CWE 主要类别。
- 对无法解析的模型预测结果进行确定性的回退：对明显良性的响应回退为 `"Benign"`，否则回退为 `"Other"`。

改进：
- 在提示构造、指标报告和混淆矩阵输出中，用简化的 CWE 主要类别替换旧版的 layer-1 类别标签及元数据。
- 通过使用单一函数来规范模型预测和 CWE 标识符，实现分类标准化的集中管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

新功能：
- 为在提示与评估中使用的每个简化 CWE 主要类别引入可读性更高的人类描述。

错误修复：
- 当 `balance_mode="layer1"` 或 `"major"` 时，确保真实标签和采样器标签都使用 CWE 主要类别。
- 对无法解析的模型预测结果进行确定性的回退：对明显良性的响应回退为 `"Benign"`，否则回退为 `"Other"`。

改进：
- 在提示构造、指标报告和混淆矩阵输出中，用简化的 CWE 主要类别替换旧版的 layer-1 类别标签及元数据。
- 通过使用单一函数来规范模型预测和 CWE 标识符，实现分类标准化的集中管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

新功能：
- 为在提示与评估中使用的每个简化 CWE 主要类别引入可读性更高的人类描述。

错误修复：
- 当 `balance_mode="layer1"` 或 `"major"` 时，确保真实标签和采样器标签都使用 CWE 主要类别。
- 对无法解析的模型预测结果进行确定性的回退：对明显良性的响应回退为 `"Benign"`，否则回退为 `"Other"`。

改进：
- 在提示构造、指标报告和混淆矩阵输出中，用简化的 CWE 主要类别替换旧版的 layer-1 类别标签及元数据。
- 通过使用单一函数来规范模型预测和 CWE 标识符，实现分类标准化的集中管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

新功能：
- 为在提示与评估中使用的每个简化 CWE 主要类别引入可读性更高的人类描述。

错误修复：
- 当 `balance_mode="layer1"` 或 `"major"` 时，确保真实标签和采样器标签都使用 CWE 主要类别。
- 对无法解析的模型预测结果进行确定性的回退：对明显良性的响应回退为 `"Benign"`，否则回退为 `"Other"`。

改进：
- 在提示构造、指标报告和混淆矩阵输出中，用简化的 CWE 主要类别替换旧版的 layer-1 类别标签及元数据。
- 通过使用单一函数来规范模型预测和 CWE 标识符，实现分类标准化的集中管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 CWE 第一层分类切换为在提示、采样和评估中一致地使用简化后的主要 CWE 类别。

新功能：
- 为在提示和评估中使用的每个简化 CWE 主要类别添加可读性良好的描述。

错误修复：
- 当 `balance_mode` 为 `"layer1"` 或 `"major"` 时，确保所用标签在真实标签和采样器标签中都能一致映射到 CWE 主要类别。
- 为无法解析的模型预测提供确定性的回退处理：将良性响应默认归为 `"Benign"`，其他则归为 `"Other"`。

增强：
- 在提示构造、指标报告以及混淆矩阵输出中，用 CWE 主要类别替换旧的第一层标签和元数据。
- 通过单一的 `canonicalize_category` 函数对预测解析和 CWE 标识进行统一处理，从而实现类别规范化的集中管理。
- 在采样器中将 `"layer1"` 视为 `"major"` 的别名，以使用同一套简化后的类别命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CWE layer-1 classification to use simplified major CWE categories consistently across prompting, sampling, and evaluation.

New Features:
- Add human-readable descriptions for each simplified CWE major category used in prompts and evaluations.

Bug Fixes:
- Ensure labels used when balance_mode is "layer1" or "major" consistently map to CWE major categories for both ground-truth and sampler labels.
- Provide deterministic fallback handling for unparseable model predictions, defaulting benign responses to "Benign" and others to "Other".

Enhancements:
- Replace legacy layer-1 labels and metadata with CWE major categories in prompt construction, metric reporting, and confusion matrix output.
- Centralize category canonicalization by routing prediction parsing and CWE identifiers through a single canonicalize_category function.
- Treat "layer1" as an alias of "major" in the sampler to use the same simplified category naming scheme.

</details>

</details>

</details>

</details>

</details>