### PR TITLE
fix: ensure balanced dev set with all categories represented

### DIFF
--- a/main.py
+++ b/main.py
@@ -905,6 +905,10 @@ class PrimeVulLayer1Pipeline:
                 str(sample_dir),
                 seed=42,
                 balance_mode=balance_mode,
+                sample_ratio=float(self.config.get("sample_ratio", 0.01)),
+                dev_ratio=float(self.config.get("dev_ratio", 0.3)),
+                remove_benign_train=bool(self.config.get("remove_benign_train", False)),
+                min_dev_per_label=int(self.config.get("min_dev_per_label", 2)),
             )
         else:
             print(f"   使用已有采样数据 {sample_dir} (balance_mode={balance_mode})")
@@ -1195,10 +1199,18 @@ def main():
                        help="自动从 checkpoint 恢复（不询问）")
     parser.add_argument(
         "--balance-mode",
-        choices=["target", "major"],
-        default="target",
-        help="采样均衡模式: target=二分类, major=CWE大类",
+        choices=["target", "major", "layer1"],
+        default="layer1",
+        help="采样均衡模式: target=二分类, major/layer1=CWE大类",
     )
+    parser.add_argument("--sample-ratio", type=float, default=0.01,
+                       help="采样比例 (默认 0.01 = 1%%)")
+    parser.add_argument("--dev-ratio", type=float, default=0.3,
+                       help="开发集比例 (默认 0.3)")
+    parser.add_argument("--remove-benign-train", action="store_true",
+                       help="从训练集中移除 Benign 样本")
+    parser.add_argument("--min-dev-per-label", type=int, default=2,
+                       help="每个类别在 dev 集中的最少样本数 (默认 2)")
     parser.add_argument(
         "--force-resample",
         action="store_true",
@@ -1219,6 +1231,10 @@ def main():
         "enable_checkpoint": not args.no_checkpoint,
         "auto_recover": args.auto_recover,
         "balance_mode": args.balance_mode,
+        "sample_ratio": args.sample_ratio,
+        "dev_ratio": args.dev_ratio,
+        "remove_benign_train": args.remove_benign_train,
+        "min_dev_per_label": args.min_dev_per_label,
         "force_resample": args.force_resample,
     }
 

--- a/src/evoprompt/data/sampler.py
+++ b/src/evoprompt/data/sampler.py
@@ -195,8 +195,14 @@ class BalancedSampler:
         dev_ratio: float = 0.3,
         target_field: str = "target",
         label_field: Optional[str] = None,
+        min_dev_per_label: int = 1,
     ) -> Tuple[List[Dict], List[Dict]]:
-        """将采样数据分割为训练集和开发集，保持平衡。"""
+        """将采样数据分割为训练集和开发集，保持平衡。
+
+        Args:
+            min_dev_per_label: 每个标签在 dev 集中的最少样本数。
+                对于样本数 >= 2 的标签，保证至少 min_dev_per_label 个进入 dev。
+        """
 
         group_field = label_field or target_field
 
@@ -213,7 +219,12 @@ class BalancedSampler:
         for label, items in label_groups.items():
             random.shuffle(items)
 
-            dev_count = int(len(items) * dev_ratio)
+            if len(items) >= 2:
+                dev_count = max(min_dev_per_label, int(len(items) * dev_ratio))
+            else:
+                # 只有 1 个样本时放入 dev 以确保评估覆盖
+                dev_count = 1
+            dev_count = min(dev_count, len(items))  # 不超过总数
             train_count = len(items) - dev_count
 
             train_data.extend(items[:train_count])
@@ -237,6 +248,10 @@ def sample_primevul_1percent(
     output_dir: str,
     seed: int = 42,
     balance_mode: str = "layer1",
+    sample_ratio: float = 0.01,
+    dev_ratio: float = 0.3,
+    remove_benign_train: bool = False,
+    min_dev_per_label: int = 1,
 ) -> Dict[str, Any]:
     """
     从Primevul数据集采样1%均衡数据的便捷函数。
@@ -272,10 +287,10 @@ def sample_primevul_1percent(
     
     logger.info(f"Using data file: {dev_file}")
     
-    # 采样1%数据
+    # 采样数据
     sampled_data, stats = sampler.sample_primevul_balanced(
         data_file=str(dev_file),
-        sample_ratio=0.1,
+        sample_ratio=sample_ratio,
         balance_mode=balance_mode,
     )
     
@@ -286,22 +301,25 @@ def sample_primevul_1percent(
     # 分割为训练和开发集
     train_data, dev_data = sampler.create_train_dev_split(
         sampled_data,
-        dev_ratio=0.3,
+        dev_ratio=dev_ratio,
         label_field="_balance_label",
+        min_dev_per_label=min_dev_per_label,
     )
 
-    original_train_len = len(train_data)
-    train_data = [item for item in train_data if item.get("_balance_label") != "Benign"]
-    removed_benign = original_train_len - len(train_data)
+    removed_benign = 0
+    if remove_benign_train:
+        original_train_len = len(train_data)
+        train_data = [item for item in train_data if item.get("_balance_label") != "Benign"]
+        removed_benign = original_train_len - len(train_data)
 
-    if removed_benign:
-        logger.info(
-            "Removed %d Benign samples from training split to focus on vulnerable categories",
-            removed_benign,
-        )
+        if removed_benign:
+            logger.info(
+                "Removed %d Benign samples from training split to focus on vulnerable categories",
+                removed_benign,
+            )
 
-    if not train_data:
-        raise ValueError("Training split is empty after removing Benign samples.")
+        if not train_data:
+            raise ValueError("Training split is empty after removing Benign samples.")
     
     # 保存数据文件
     files = {}
@@ -336,13 +354,14 @@ def sample_primevul_1percent(
     stats["train_without_benign"] = len(train_data)
     stats["train_removed_benign"] = removed_benign
     stats["sampling_config"] = {
-        "sample_ratio": 0.01,
-        "dev_ratio": 0.3,
+        "sample_ratio": sample_ratio,
+        "dev_ratio": dev_ratio,
         "seed": seed,
         "source_file": str(dev_file),
         "balance_mode": balance_mode,
-        "train_remove_benign": True,
+        "train_remove_benign": remove_benign_train,
         "removed_benign_train": removed_benign,
+        "min_dev_per_label": min_dev_per_label,
     }
     
     with open(stats_file, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary

- Fix `create_train_dev_split` rounding bug: `int(len * 0.3)` gives 0 for small categories, leaving dev set with only Benign samples
- Add `min_dev_per_label` parameter (default=2) guaranteeing each category appears in dev set
- Make `sample_ratio`, `dev_ratio`, `remove_benign_train` configurable via CLI
- Fix hardcoded `sample_ratio=0.1` (was mislabeled as "1percent")

**Before:** dev set = 70 Benign, 0 vulnerable → macro-F1 meaningless
**After:** dev set = 51 samples across all 11 categories (2-6 per category)

## Test plan

- [x] `py_compile` passes for both changed files
- [x] Verified dev set distribution: all 11 categories present (Benign:6, Buffer Errors:6, Concurrency:2, Crypto:2, Info Exposure:6, Injection:3, Integer Errors:6, Memory Mgmt:6, Other:6, Path Traversal:2, Pointer Deref:6)
- [ ] Smoke test with `--balance-mode layer1 --force-resample --min-dev-per-label 2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

确保 PrimeVul 抽样流水线在具有可配置的抽样与切分参数的前提下，生成一个平衡的开发集（dev set）。

New Features:
- 在训练集/开发集划分中增加“每个标签的最小样本数”约束，以保证每个标签在开发集中都有所体现。
- 将样本比例、开发集比例、benign 移除行为，以及每个标签的开发集最小样本数暴露为可配置的 CLI 和配置项。

Bug Fixes:
- 修正开发集划分大小的计算问题，此前在小类别上会产生 0 个开发集样本，从而导致开发集不平衡。
- 修复 PrimeVul 抽样中使用的硬编码抽样比例，使其遵从配置中的样本比例，而不是错误的常量值。

Enhancements:
- 扩展抽样辅助工具和统计输出，用于记录实际生效的抽样与切分配置，包括 benign 移除行为以及每个标签的开发集最小值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the PrimeVul sampling pipeline produces a balanced dev set with configurable sampling and split parameters.

New Features:
- Add a minimum-per-label constraint to the train/dev split to guarantee each label is represented in the dev set.
- Expose sample ratio, dev ratio, benign-removal behavior, and minimum dev samples per label as configurable CLI and config options.

Bug Fixes:
- Correct the dev split size calculation that previously yielded zero dev samples for small categories, leading to an imbalanced dev set.
- Fix the hardcoded sampling ratio used in PrimeVul sampling so it honors the configured sample ratio instead of an incorrect constant value.

Enhancements:
- Extend the sampling helper and stats output to record the effective sampling and split configuration, including benign-removal behavior and per-label dev minimums.

</details>