### PR TITLE
feat: default sample-ratio to 10% for meaningful minority-class evaluation

### DIFF
--- a/main.py
+++ b/main.py
@@ -866,16 +866,17 @@ class PrimeVulLayer1Pipeline:
             regenerate_samples = True
 
         if regenerate_samples:
-            print(f"   生成 1% 采样数据到 {sample_dir} (balance_mode={balance_mode})")
+            ratio_pct = float(self.config.get("sample_ratio", 0.10)) * 100
+            print(f"   生成 {ratio_pct:.0f}% 采样数据到 {sample_dir} (balance_mode={balance_mode})")
             sample_primevul_1percent(
                 str(primevul_dir),
                 str(sample_dir),
                 seed=42,
                 balance_mode=balance_mode,
-                sample_ratio=float(self.config.get("sample_ratio", 0.01)),
+                sample_ratio=float(self.config.get("sample_ratio", 0.10)),
                 dev_ratio=float(self.config.get("dev_ratio", 0.3)),
                 remove_benign_train=bool(self.config.get("remove_benign_train", False)),
-                min_dev_per_label=int(self.config.get("min_dev_per_label", 2)),
+                min_dev_per_label=int(self.config.get("min_dev_per_label", 5)),
             )
         else:
             print(f"   使用已有采样数据 {sample_dir} (balance_mode={balance_mode})")
@@ -1181,14 +1182,14 @@ def main():
         default="layer1",
         help="采样均衡模式: target=二分类, major/layer1=CWE大类",
     )
-    parser.add_argument("--sample-ratio", type=float, default=0.01,
-                       help="采样比例 (默认 0.01 = 1%%)")
+    parser.add_argument("--sample-ratio", type=float, default=0.10,
+                       help="采样比例 (默认 0.10 = 10%%)")
     parser.add_argument("--dev-ratio", type=float, default=0.3,
                        help="开发集比例 (默认 0.3)")
     parser.add_argument("--remove-benign-train", action="store_true",
                        help="从训练集中移除 Benign 样本")
-    parser.add_argument("--min-dev-per-label", type=int, default=2,
-                       help="每个类别在 dev 集中的最少样本数 (默认 2)")
+    parser.add_argument("--min-dev-per-label", type=int, default=5,
+                       help="每个类别在 dev 集中的最少样本数 (默认 5)")
     parser.add_argument(
         "--force-resample",
         action="store_true",


### PR DESCRIPTION
## Summary
- Bump `--sample-ratio` default from 0.01 (1%) to 0.10 (10%) so minority CWE classes get enough samples for reliable F1 estimates
- Bump `--min-dev-per-label` default from 2 to 5 to ensure each category has a meaningful dev set
- Make the sampling log message dynamic (shows actual ratio instead of hardcoded "1%")

## Motivation
At 1% sampling, minority classes get 1-4 samples making F1 estimates unreliable.
Ablation: 1% -> 5/11 categories with F1>0; 10% -> 8/11 categories.

## Test plan
- [x] `uv run python -m py_compile main.py` passes
- [ ] Run a quick experiment with default settings and verify 10% sampling is used
- [ ] Verify `--sample-ratio 0.01` still works as an override

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

更新默认数据采样参数，以在保持可配置覆盖设置的同时，提高评估子集的代表性。

增强内容：
- 将默认采样比例从 1% 提升至 10%，并将每个标签的最小开发集样本数从 2 提升至 5，以获得更可靠的按类别评估结果。
- 调整采样日志输出，以显示实际使用的采样百分比，而不是硬编码的固定值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update default data sampling parameters to improve representativeness of evaluation subsets while keeping overrides configurable.

Enhancements:
- Increase default sample ratio from 1% to 10% and minimum dev samples per label from 2 to 5 for more reliable per-class evaluation.
- Adjust sampling log output to display the actual sampling percentage used instead of a hardcoded value.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新默认数据采样参数，以在保持可配置覆盖设置的同时，提高评估子集的代表性。

增强内容：
- 将默认采样比例从 1% 提升至 10%，并将每个标签的最小开发集样本数从 2 提升至 5，以获得更可靠的按类别评估结果。
- 调整采样日志输出，以显示实际使用的采样百分比，而不是硬编码的固定值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update default data sampling parameters to improve representativeness of evaluation subsets while keeping overrides configurable.

Enhancements:
- Increase default sample ratio from 1% to 10% and minimum dev samples per label from 2 to 5 for more reliable per-class evaluation.
- Adjust sampling log output to display the actual sampling percentage used instead of a hardcoded value.

</details>

</details>