### PR TITLE
feat: use macro-F1 as default fitness metric

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,15 +84,20 @@ def get_fitness(config: Dict[str, Any], eval_result: Dict[str, Any]) -> Tuple[st
             fallback,
         )
         fitness_metric = fallback
-    fitness = eval_result[fitness_metric]
+    fitness = eval_result.get(fitness_metric, 0.0)
+    if fitness_metric not in eval_result:
+        logger.warning(
+            "Fallback metric %r also missing from eval_result; using 0.0",
+            fitness_metric,
+        )
     return fitness_metric, fitness
 
 
 def _safe_metric(result: Dict[str, Any], key: str, default: float = 0.0) -> float:
-    """Return ``result[key]`` if present, else *default* with a warning."""
+    """Return ``result[key]`` if present, else *default* with a debug log."""
     if key in result:
         return result[key]
-    logger.warning("Metric %r missing from result dict; defaulting to %.1f", key, default)
+    logger.debug("Metric %r missing from result dict; defaulting to %.1f", key, default)
     return default
 
 

--- a/main.py
+++ b/main.py
@@ -781,11 +781,17 @@ class PrimeVulLayer1Pipeline:
             labels=CWE_MAJOR_CATEGORIES
         )
 
+        # Extract macro / weighted F1 for fitness selection
+        macro_f1 = report.get("macro avg", {}).get("f1-score", 0.0)
+        weighted_f1 = report.get("weighted avg", {}).get("f1-score", 0.0)
+
         return {
             "prompt_id": prompt_id,
             "generation": generation,
             "final_prompt": current_prompt,
             "accuracy": overall_accuracy,
+            "macro_f1": macro_f1,
+            "weighted_f1": weighted_f1,
             "total_samples": total_samples,
             "num_batches": num_batches,
             "batch_analyses": batch_analyses,
@@ -912,9 +918,10 @@ class PrimeVulLayer1Pipeline:
                     prompt_id=f"initial_{i}", enable_evolution=False
                 )
                 individual = Individual(prompt)
-                individual.fitness = result["accuracy"]
+                fitness_metric = self.config.get("fitness_metric", "macro_f1")
+                individual.fitness = result["macro_f1"] if fitness_metric == "macro_f1" else result["accuracy"]
                 population.append((individual, result))
-                print(f"    ✓ 适应度: {individual.fitness:.4f}")
+                print(f"    ✓ 适应度: {individual.fitness:.4f} ({fitness_metric})")
 
             # 保存初始 checkpoint
             self.checkpoint_manager.save_checkpoint(
@@ -965,10 +972,11 @@ class PrimeVulLayer1Pipeline:
                     )
 
                     evolved_individual = Individual(evolved_prompt)
-                    evolved_individual.fitness = eval_result["accuracy"]
+                    fitness_metric = self.config.get("fitness_metric", "macro_f1")
+                    evolved_individual.fitness = eval_result["macro_f1"] if fitness_metric == "macro_f1" else eval_result["accuracy"]
 
-                    print(f"    进化前适应度: {best_individual.fitness:.4f}")
-                    print(f"    进化后适应度: {evolved_individual.fitness:.4f}")
+                    print(f"    进化前适应度: {best_individual.fitness:.4f} ({fitness_metric})")
+                    print(f"    进化后适应度: {evolved_individual.fitness:.4f} ({fitness_metric})")
 
                     if evolved_individual.fitness > best_individual.fitness:
                         print(f"    ✅ 接受进化后的 prompt!")
@@ -1070,11 +1078,16 @@ class PrimeVulLayer1Pipeline:
 
         # 3. 保存分类报告的易读版本
         readable_report_file = self.exp_dir / "classification_report.txt"
+        fitness_metric = self.config.get("fitness_metric", "macro_f1")
         with open(readable_report_file, "w", encoding="utf-8") as f:
             f.write(f"PrimeVul Layer-1 分类报告\n")
             f.write(f"{'='*80}\n")
             f.write(f"实验 ID: {self.exp_id}\n")
-            f.write(f"最终准确率: {best_individual.fitness:.4f}\n")
+            f.write(f"适应度指标: {fitness_metric}\n")
+            f.write(f"最终适应度: {best_individual.fitness:.4f}\n")
+            f.write(f"准确率: {best_result['accuracy']:.4f}\n")
+            f.write(f"Macro F1: {best_result['macro_f1']:.4f}\n")
+            f.write(f"Weighted F1: {best_result['weighted_f1']:.4f}\n")
             f.write(f"总样本数: {best_result['total_samples']}\n")
             f.write(f"Batch 大小: {self.batch_size}\n")
             f.write(f"Batch 总数: {best_result['num_batches']}\n\n")
@@ -1122,7 +1135,11 @@ class PrimeVulLayer1Pipeline:
             "experiment_id": self.exp_id,
             "timestamp": datetime.now().isoformat(),
             "config": self.config,
+            "fitness_metric": self.config.get("fitness_metric", "macro_f1"),
             "best_fitness": best_individual.fitness,
+            "accuracy": best_result["accuracy"],
+            "macro_f1": best_result["macro_f1"],
+            "weighted_f1": best_result["weighted_f1"],
             "best_prompt": best_individual.prompt,
             "total_samples": best_result["total_samples"],
             "num_batches": best_result["num_batches"],
@@ -1182,6 +1199,8 @@ def main():
         default="layer1",
         help="采样均衡模式: target=二分类, major/layer1=CWE大类",
     )
+    parser.add_argument("--fitness-metric", choices=["accuracy", "macro_f1"], default="macro_f1",
+                       help="进化适应度指标 (default: macro_f1)")
     parser.add_argument("--sample-ratio", type=float, default=0.10,
                        help="采样比例 (默认 0.10 = 10%%)")
     parser.add_argument("--dev-ratio", type=float, default=0.3,
@@ -1221,6 +1240,7 @@ def main():
         "auto_recover": args.auto_recover,
         "mode": args.mode,
         "balance_mode": args.balance_mode,
+        "fitness_metric": args.fitness_metric,
         "sample_ratio": args.sample_ratio,
         "dev_ratio": args.dev_ratio,
         "remove_benign_train": args.remove_benign_train,

--- a/main.py
+++ b/main.py
@@ -70,6 +70,12 @@ def get_fitness(config: Dict[str, Any], eval_result: Dict[str, Any]) -> Tuple[st
             f"Unknown fitness_metric {fitness_metric!r}; "
             f"expected one of {sorted(VALID_FITNESS_METRICS)}"
         )
+    if fitness_metric not in eval_result:
+        raise KeyError(
+            f"Fitness metric {fitness_metric!r} not found in eval_result "
+            f"(available keys: {sorted(eval_result.keys())}). "
+            f"This may happen when resuming from an older checkpoint."
+        )
     fitness = eval_result[fitness_metric]
     return fitness_metric, fitness
 
@@ -1233,7 +1239,7 @@ def main():
         default="layer1",
         help="采样均衡模式: target=二分类, major/layer1=CWE大类",
     )
-    parser.add_argument("--fitness-metric", choices=["accuracy", "macro_f1"], default=DEFAULT_FITNESS_METRIC,
+    parser.add_argument("--fitness-metric", choices=sorted(VALID_FITNESS_METRICS), default=DEFAULT_FITNESS_METRIC,
                        help=f"进化适应度指标 (default: {DEFAULT_FITNESS_METRIC})")
     parser.add_argument("--sample-ratio", type=float, default=0.10,
                        help="采样比例 (默认 0.10 = 10%%)")

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ EvoPrompt Main Entry - PrimeVul Layer-1 并发漏洞分类
 5. 输出最终 prompt 和各类别的 precision/recall/f1-score 到 result/ 文件夹
 """
 
+import logging
 import sys
 import json
 import time
@@ -49,6 +50,9 @@ import numpy as np
 # Used by both the CLI argument parser and all config.get() fallbacks
 # so that changing the default in one place keeps everything in sync.
 DEFAULT_FITNESS_METRIC = "macro_f1"
+VALID_FITNESS_METRICS = {"accuracy", "macro_f1"}
+
+logger = logging.getLogger(__name__)
 
 
 def get_fitness(config: Dict[str, Any], eval_result: Dict[str, Any]) -> Tuple[str, float]:
@@ -56,13 +60,26 @@ def get_fitness(config: Dict[str, Any], eval_result: Dict[str, Any]) -> Tuple[st
 
     Centralises the fitness-metric lookup that was previously duplicated in the
     initial-evaluation loop and the per-generation evolution loop.
+
+    Raises ``ValueError`` if the configured metric is not in
+    :data:`VALID_FITNESS_METRICS`.
     """
     fitness_metric = config.get("fitness_metric", DEFAULT_FITNESS_METRIC)
-    if fitness_metric == "macro_f1":
-        fitness = eval_result["macro_f1"]
-    else:
-        fitness = eval_result["accuracy"]
+    if fitness_metric not in VALID_FITNESS_METRICS:
+        raise ValueError(
+            f"Unknown fitness_metric {fitness_metric!r}; "
+            f"expected one of {sorted(VALID_FITNESS_METRICS)}"
+        )
+    fitness = eval_result[fitness_metric]
     return fitness_metric, fitness
+
+
+def _safe_metric(result: Dict[str, Any], key: str, default: float = 0.0) -> float:
+    """Return ``result[key]`` if present, else *default* with a warning."""
+    if key in result:
+        return result[key]
+    logger.warning("Metric %r missing from result dict; defaulting to %.1f", key, default)
+    return default
 
 
 class BatchAnalyzer:
@@ -1102,9 +1119,9 @@ class PrimeVulLayer1Pipeline:
             f.write(f"实验 ID: {self.exp_id}\n")
             f.write(f"适应度指标: {fitness_metric}\n")
             f.write(f"最终适应度: {best_individual.fitness:.4f}\n")
-            f.write(f"准确率: {best_result.get('accuracy', 0.0):.4f}\n")
-            f.write(f"Macro F1: {best_result.get('macro_f1', 0.0):.4f}\n")
-            f.write(f"Weighted F1: {best_result.get('weighted_f1', 0.0):.4f}\n")
+            f.write(f"准确率: {_safe_metric(best_result, 'accuracy'):.4f}\n")
+            f.write(f"Macro F1: {_safe_metric(best_result, 'macro_f1'):.4f}\n")
+            f.write(f"Weighted F1: {_safe_metric(best_result, 'weighted_f1'):.4f}\n")
             f.write(f"总样本数: {best_result['total_samples']}\n")
             f.write(f"Batch 大小: {self.batch_size}\n")
             f.write(f"Batch 总数: {best_result['num_batches']}\n\n")
@@ -1154,9 +1171,9 @@ class PrimeVulLayer1Pipeline:
             "config": self.config,
             "fitness_metric": self.config.get("fitness_metric", DEFAULT_FITNESS_METRIC),
             "best_fitness": best_individual.fitness,
-            "accuracy": best_result.get("accuracy", 0.0),
-            "macro_f1": best_result.get("macro_f1", 0.0),
-            "weighted_f1": best_result.get("weighted_f1", 0.0),
+            "accuracy": _safe_metric(best_result, "accuracy"),
+            "macro_f1": _safe_metric(best_result, "macro_f1"),
+            "weighted_f1": _safe_metric(best_result, "weighted_f1"),
             "best_prompt": best_individual.prompt,
             "total_samples": best_result["total_samples"],
             "num_batches": best_result["num_batches"],

--- a/main.py
+++ b/main.py
@@ -45,6 +45,25 @@ from evoprompt.utils.text import safe_format
 from sklearn.metrics import classification_report, confusion_matrix
 import numpy as np
 
+# Module-level constant for the default fitness metric.
+# Used by both the CLI argument parser and all config.get() fallbacks
+# so that changing the default in one place keeps everything in sync.
+DEFAULT_FITNESS_METRIC = "macro_f1"
+
+
+def get_fitness(config: Dict[str, Any], eval_result: Dict[str, Any]) -> Tuple[str, float]:
+    """Return (metric_name, fitness_value) from *eval_result* based on *config*.
+
+    Centralises the fitness-metric lookup that was previously duplicated in the
+    initial-evaluation loop and the per-generation evolution loop.
+    """
+    fitness_metric = config.get("fitness_metric", DEFAULT_FITNESS_METRIC)
+    if fitness_metric == "macro_f1":
+        fitness = eval_result["macro_f1"]
+    else:
+        fitness = eval_result["accuracy"]
+    return fitness_metric, fitness
+
 
 class BatchAnalyzer:
     """Batch 级别的分析器，对比预测结果和 ground truth 并生成反馈"""
@@ -918,8 +937,7 @@ class PrimeVulLayer1Pipeline:
                     prompt_id=f"initial_{i}", enable_evolution=False
                 )
                 individual = Individual(prompt)
-                fitness_metric = self.config.get("fitness_metric", "macro_f1")
-                individual.fitness = result["macro_f1"] if fitness_metric == "macro_f1" else result["accuracy"]
+                fitness_metric, individual.fitness = get_fitness(self.config, result)
                 population.append((individual, result))
                 print(f"    ✓ 适应度: {individual.fitness:.4f} ({fitness_metric})")
 
@@ -972,8 +990,7 @@ class PrimeVulLayer1Pipeline:
                     )
 
                     evolved_individual = Individual(evolved_prompt)
-                    fitness_metric = self.config.get("fitness_metric", "macro_f1")
-                    evolved_individual.fitness = eval_result["macro_f1"] if fitness_metric == "macro_f1" else eval_result["accuracy"]
+                    fitness_metric, evolved_individual.fitness = get_fitness(self.config, eval_result)
 
                     print(f"    进化前适应度: {best_individual.fitness:.4f} ({fitness_metric})")
                     print(f"    进化后适应度: {evolved_individual.fitness:.4f} ({fitness_metric})")
@@ -1078,16 +1095,16 @@ class PrimeVulLayer1Pipeline:
 
         # 3. 保存分类报告的易读版本
         readable_report_file = self.exp_dir / "classification_report.txt"
-        fitness_metric = self.config.get("fitness_metric", "macro_f1")
+        fitness_metric = self.config.get("fitness_metric", DEFAULT_FITNESS_METRIC)
         with open(readable_report_file, "w", encoding="utf-8") as f:
             f.write(f"PrimeVul Layer-1 分类报告\n")
             f.write(f"{'='*80}\n")
             f.write(f"实验 ID: {self.exp_id}\n")
             f.write(f"适应度指标: {fitness_metric}\n")
             f.write(f"最终适应度: {best_individual.fitness:.4f}\n")
-            f.write(f"准确率: {best_result['accuracy']:.4f}\n")
-            f.write(f"Macro F1: {best_result['macro_f1']:.4f}\n")
-            f.write(f"Weighted F1: {best_result['weighted_f1']:.4f}\n")
+            f.write(f"准确率: {best_result.get('accuracy', 0.0):.4f}\n")
+            f.write(f"Macro F1: {best_result.get('macro_f1', 0.0):.4f}\n")
+            f.write(f"Weighted F1: {best_result.get('weighted_f1', 0.0):.4f}\n")
             f.write(f"总样本数: {best_result['total_samples']}\n")
             f.write(f"Batch 大小: {self.batch_size}\n")
             f.write(f"Batch 总数: {best_result['num_batches']}\n\n")
@@ -1135,11 +1152,11 @@ class PrimeVulLayer1Pipeline:
             "experiment_id": self.exp_id,
             "timestamp": datetime.now().isoformat(),
             "config": self.config,
-            "fitness_metric": self.config.get("fitness_metric", "macro_f1"),
+            "fitness_metric": self.config.get("fitness_metric", DEFAULT_FITNESS_METRIC),
             "best_fitness": best_individual.fitness,
-            "accuracy": best_result["accuracy"],
-            "macro_f1": best_result["macro_f1"],
-            "weighted_f1": best_result["weighted_f1"],
+            "accuracy": best_result.get("accuracy", 0.0),
+            "macro_f1": best_result.get("macro_f1", 0.0),
+            "weighted_f1": best_result.get("weighted_f1", 0.0),
             "best_prompt": best_individual.prompt,
             "total_samples": best_result["total_samples"],
             "num_batches": best_result["num_batches"],
@@ -1199,8 +1216,8 @@ def main():
         default="layer1",
         help="采样均衡模式: target=二分类, major/layer1=CWE大类",
     )
-    parser.add_argument("--fitness-metric", choices=["accuracy", "macro_f1"], default="macro_f1",
-                       help="进化适应度指标 (default: macro_f1)")
+    parser.add_argument("--fitness-metric", choices=["accuracy", "macro_f1"], default=DEFAULT_FITNESS_METRIC,
+                       help=f"进化适应度指标 (default: {DEFAULT_FITNESS_METRIC})")
     parser.add_argument("--sample-ratio", type=float, default=0.10,
                        help="采样比例 (默认 0.10 = 10%%)")
     parser.add_argument("--dev-ratio", type=float, default=0.3,

--- a/main.py
+++ b/main.py
@@ -62,7 +62,9 @@ def get_fitness(config: Dict[str, Any], eval_result: Dict[str, Any]) -> Tuple[st
     initial-evaluation loop and the per-generation evolution loop.
 
     Raises ``ValueError`` if the configured metric is not in
-    :data:`VALID_FITNESS_METRICS`.
+    :data:`VALID_FITNESS_METRICS`.  If the chosen metric is absent from
+    *eval_result* (e.g. when resuming from an older checkpoint), falls back to
+    ``"accuracy"`` with a warning instead of crashing.
     """
     fitness_metric = config.get("fitness_metric", DEFAULT_FITNESS_METRIC)
     if fitness_metric not in VALID_FITNESS_METRICS:
@@ -71,11 +73,17 @@ def get_fitness(config: Dict[str, Any], eval_result: Dict[str, Any]) -> Tuple[st
             f"expected one of {sorted(VALID_FITNESS_METRICS)}"
         )
     if fitness_metric not in eval_result:
-        raise KeyError(
-            f"Fitness metric {fitness_metric!r} not found in eval_result "
-            f"(available keys: {sorted(eval_result.keys())}). "
-            f"This may happen when resuming from an older checkpoint."
+        # Gracefully handle older checkpoints that lack newer metrics.
+        fallback = "accuracy"
+        logger.warning(
+            "Fitness metric %r not found in eval_result "
+            "(available keys: %s); falling back to %r. "
+            "This can happen when resuming from an older checkpoint.",
+            fitness_metric,
+            sorted(eval_result.keys()),
+            fallback,
         )
+        fitness_metric = fallback
     fitness = eval_result[fitness_metric]
     return fitness_metric, fitness
 


### PR DESCRIPTION
## Summary
- Add `--fitness-metric` CLI flag (`accuracy` | `macro_f1`, default `macro_f1`) to control which metric drives evolution selection
- Extract macro-F1 and weighted-F1 from `classification_report` and include both in the evaluation result dict
- Update fitness assignment in `run_evolution` (initial eval + evolved eval) to respect the configured metric
- Record `fitness_metric`, `accuracy`, `macro_f1`, and `weighted_f1` in `experiment_summary.json` and `classification_report.txt`

## Motivation
On imbalanced vulnerability datasets (e.g., PrimeVul), accuracy is dominated by the majority class. A model that predicts "Benign" for everything can score high accuracy while completely missing rare CWE categories. Macro-F1 weights every category equally, so the evolution process is incentivized to improve recall on under-represented vulnerability types.

## Test plan
- [ ] `uv run python -m py_compile main.py` passes (verified)
- [ ] Run a short experiment (`--max-generations 1`) with `--fitness-metric macro_f1` and confirm `experiment_summary.json` contains all three metrics
- [ ] Run with `--fitness-metric accuracy` and confirm the old behavior is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

</details>

</details>

</details>

新特性：
- 新增 `--fitness-metric` CLI 参数及对应的配置项，用于在 `accuracy` 和 `macro_F1` 之间选择作为进化适应度指标。
- 在评估结果和实验摘要输出中增加 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 根据配置的适应度指标为初始个体和进化后的个体分配适应度，不再始终固定使用准确率（accuracy）。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度值以及所有关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

新功能：
- 添加可配置的 `--fitness-metric` CLI 选项及对应的配置字段，用于在准确率（accuracy）和宏平均 F1（macro-F1）之间选择进化适应度指标。
- 在每次运行的评估结果中加入宏平均 F1（macro-F1）和加权 F1（weighted-F1）评分。

改进：
- 在一个辅助函数中集中处理适应度指标的选择，并将其用于初始评估和每一代（per-generation）评估。
- 扩展实验报告（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度指标、最终适应度，以及关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

新功能：
- 添加 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 `macro_F1` 之间选择作为进化适应度度量，默认值为 `macro_F1`。
- 在每次运行的评估结果中加入 `macro_F1` 和 `weighted_F1` 分数。

增强改进：
- 将适应度度量的选择集中在一个辅助函数中，供初始评估和每代评估复用，并对旧检查点提供向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、`macro_F1` 和 `weighted_F1` 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

让进化过程使用可配置的适应度度量，并在实验输出中持久化更丰富的评估指标。

New Features:
- 添加可配置的 `--fitness-metric` CLI 选项和配置字段，用于在 accuracy 和 macro-F1 之间选择作为进化适应度度量，默认使用 macro-F1。
- 在进化循环使用的每个评估结果中包含 macro-F1 和 weighted-F1 分数。

Enhancements:
- 将适应度度量的选择集中到一个辅助方法中，在从旧检查点恢复时支持向后兼容的回退逻辑。
- 扩展实验输出（`classification_report.txt` 和 `experiment_summary.json`），记录所选适应度度量、最终适应度，以及包括 accuracy、macro-F1 和 weighted-F1 在内的关键分类指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the evolution process use a configurable fitness metric and persist richer evaluation metrics in experiment outputs.

New Features:
- Add a configurable --fitness-metric CLI option and config field to choose between accuracy and macro-F1 as the evolution fitness metric, defaulting to macro-F1.
- Include macro-F1 and weighted-F1 scores in each evaluation result used by the evolution loop.

Enhancements:
- Centralize fitness metric selection into a helper that supports backwards-compatible fallbacks when resuming from older checkpoints.
- Extend experiment outputs (classification_report.txt and experiment_summary.json) to record the chosen fitness metric, final fitness, and key classification metrics including accuracy, macro-F1, and weighted-F1.

</details>

</details>

</details>

</details>

</details>

</details>

</details>