### PR TITLE
feat: per-category F1 regression guard during evolution

### DIFF
--- a/main.py
+++ b/main.py
@@ -812,6 +812,10 @@ class PrimeVulLayer1Pipeline:
 
         Returns (passed: bool, regressions: list of (category, old_f1, new_f1, drop))
         """
+        if not (0.0 <= max_drop <= 1.0):
+            raise ValueError(
+                f"max_drop must be between 0.0 and 1.0, got {max_drop}"
+            )
         regressions = []
         # Use all known categories, but also check for unexpected ones in reports
         all_categories = set(CWE_MAJOR_CATEGORIES)

--- a/main.py
+++ b/main.py
@@ -438,6 +438,9 @@ class PromptEvolver:
 
 DEFAULT_MAX_CATEGORY_DROP = 0.15
 
+# sklearn classification_report aggregate keys that are not real categories
+_REPORT_AGGREGATE_KEYS = frozenset({"accuracy", "macro avg", "weighted avg", "micro avg"})
+
 
 class PrimeVulLayer1Pipeline:
     """PrimeVul Layer-1 并发漏洞分类流水线"""
@@ -814,13 +817,15 @@ class PrimeVulLayer1Pipeline:
         Returns (passed: bool, regressions: list of (category, old_f1, new_f1, drop))
         """
         regressions = []
-        # Aggregate keys exclude list (sklearn classification_report aggregates)
-        _AGGREGATE_KEYS = {"accuracy", "macro avg", "weighted avg"}
-        all_categories = set(CWE_MAJOR_CATEGORIES) | {
-            k for k in set(old_report) | set(new_report)
-            if k not in _AGGREGATE_KEYS
-            and (isinstance(old_report.get(k), dict) or isinstance(new_report.get(k), dict))
-        }
+        # Start with known CWE categories, then add any extra report keys
+        # that look like per-class entries (dict with "f1-score").
+        all_categories = set(CWE_MAJOR_CATEGORIES)
+        for k in set(old_report) | set(new_report):
+            if k in _REPORT_AGGREGATE_KEYS or k in all_categories:
+                continue
+            entry = old_report.get(k) or new_report.get(k)
+            if isinstance(entry, dict) and "f1-score" in entry:
+                all_categories.add(k)
 
         for cat in sorted(all_categories):
             old_entry = old_report.get(cat)

--- a/main.py
+++ b/main.py
@@ -795,6 +795,25 @@ class PrimeVulLayer1Pipeline:
             "ground_truths": all_ground_truths,
         }
 
+    def _check_category_regression(
+        self,
+        old_report: Dict[str, Any],
+        new_report: Dict[str, Any],
+        max_drop: float,
+    ) -> Tuple[bool, List[Tuple[str, float, float, float]]]:
+        """Check if any category F1 dropped more than max_drop.
+
+        Returns (passed: bool, regressions: list of (category, old_f1, new_f1, drop))
+        """
+        regressions = []
+        for cat in CWE_MAJOR_CATEGORIES:
+            old_f1 = old_report.get(cat, {}).get("f1-score", 0.0)
+            new_f1 = new_report.get(cat, {}).get("f1-score", 0.0)
+            drop = old_f1 - new_f1
+            if old_f1 > 0 and drop > max_drop:
+                regressions.append((cat, old_f1, new_f1, drop))
+        return len(regressions) == 0, regressions
+
     def run_evolution(self) -> Dict[str, Any]:
         """运行完整的进化流程 (支持断点恢复)"""
         print("\n" + "="*80)
@@ -971,8 +990,20 @@ class PrimeVulLayer1Pipeline:
                     print(f"    进化后适应度: {evolved_individual.fitness:.4f}")
 
                     if evolved_individual.fitness > best_individual.fitness:
-                        print(f"    ✅ 接受进化后的 prompt!")
-                        population[0] = (evolved_individual, eval_result)
+                        # Check for category regression before accepting
+                        max_drop = self.config.get("max_category_drop", 0.15)
+                        passed, regressions = self._check_category_regression(
+                            best_result["classification_report"],
+                            eval_result["classification_report"],
+                            max_drop,
+                        )
+                        if not passed:
+                            print(f"    ⚠️ 拒绝进化: 类别退化超过阈值")
+                            for cat, old_f1, new_f1, drop in regressions:
+                                print(f"      {cat}: {old_f1:.3f} → {new_f1:.3f} (↓{drop:.3f})")
+                        else:
+                            print(f"    ✅ 接受进化后的 prompt!")
+                            population[0] = (evolved_individual, eval_result)
                     else:
                         print(f"    ❌ 保留原 prompt")
 
@@ -1205,6 +1236,12 @@ def main():
         action="store_true",
         help="启用错误累积+元学习调优",
     )
+    parser.add_argument(
+        "--max-category-drop",
+        type=float,
+        default=0.15,
+        help="最大允许的单类别 F1 下降幅度 (default: 0.15)",
+    )
 
     args = parser.parse_args()
 
@@ -1228,6 +1265,7 @@ def main():
         "force_resample": args.force_resample,
         "enable_rag": args.enable_rag,
         "enable_meta": args.enable_meta,
+        "max_category_drop": args.max_category_drop,
     }
 
     # 创建并运行 pipeline

--- a/main.py
+++ b/main.py
@@ -829,14 +829,10 @@ class PrimeVulLayer1Pipeline:
             new_entry = new_report.get(cat)
             if old_entry is None and new_entry is None:
                 continue
-            if old_entry is None:
-                print(f"      [info] category '{cat}' missing from old report, skipping regression check")
-                continue
-            if new_entry is None:
-                print(f"      [info] category '{cat}' missing from new report, skipping regression check")
-                continue
-            old_f1 = old_entry.get("f1-score", 0.0)
-            new_f1 = new_entry.get("f1-score", 0.0)
+            old_f1 = old_entry.get("f1-score", 0.0) if old_entry is not None else 0.0
+            # Treat a category that disappeared from the new report as f1=0.0
+            # so that dropping a previously-evaluated category counts as regression
+            new_f1 = new_entry.get("f1-score", 0.0) if new_entry is not None else 0.0
             drop = old_f1 - new_f1
             if old_f1 > 0 and drop > max_drop:
                 regressions.append((cat, old_f1, new_f1, drop))

--- a/main.py
+++ b/main.py
@@ -436,6 +436,9 @@ class PromptEvolver:
         return stripped[:limit].rstrip() + "\n... (truncated)"
 
 
+DEFAULT_MAX_CATEGORY_DROP = 0.15
+
+
 class PrimeVulLayer1Pipeline:
     """PrimeVul Layer-1 并发漏洞分类流水线"""
 
@@ -803,12 +806,33 @@ class PrimeVulLayer1Pipeline:
     ) -> Tuple[bool, List[Tuple[str, float, float, float]]]:
         """Check if any category F1 dropped more than max_drop.
 
+        Iterates over the union of categories present in both reports
+        (intersected with CWE_MAJOR_CATEGORIES) and logs when a category
+        is missing from either report.
+
         Returns (passed: bool, regressions: list of (category, old_f1, new_f1, drop))
         """
         regressions = []
-        for cat in CWE_MAJOR_CATEGORIES:
-            old_f1 = old_report.get(cat, {}).get("f1-score", 0.0)
-            new_f1 = new_report.get(cat, {}).get("f1-score", 0.0)
+        # Use all known categories, but also check for unexpected ones in reports
+        all_categories = set(CWE_MAJOR_CATEGORIES)
+        for key in list(old_report.keys()) + list(new_report.keys()):
+            if isinstance(old_report.get(key), dict) or isinstance(new_report.get(key), dict):
+                if key not in all_categories and key not in ("accuracy", "macro avg", "weighted avg"):
+                    all_categories.add(key)
+
+        for cat in sorted(all_categories):
+            old_entry = old_report.get(cat)
+            new_entry = new_report.get(cat)
+            if old_entry is None and new_entry is None:
+                continue
+            if old_entry is None:
+                print(f"      [info] category '{cat}' missing from old report, skipping regression check")
+                continue
+            if new_entry is None:
+                print(f"      [info] category '{cat}' missing from new report, skipping regression check")
+                continue
+            old_f1 = old_entry.get("f1-score", 0.0)
+            new_f1 = new_entry.get("f1-score", 0.0)
             drop = old_f1 - new_f1
             if old_f1 > 0 and drop > max_drop:
                 regressions.append((cat, old_f1, new_f1, drop))
@@ -991,14 +1015,14 @@ class PrimeVulLayer1Pipeline:
 
                     if evolved_individual.fitness > best_individual.fitness:
                         # Check for category regression before accepting
-                        max_drop = self.config.get("max_category_drop", 0.15)
+                        max_drop = self.config.get("max_category_drop", DEFAULT_MAX_CATEGORY_DROP)
                         passed, regressions = self._check_category_regression(
                             best_result["classification_report"],
                             eval_result["classification_report"],
                             max_drop,
                         )
                         if not passed:
-                            print(f"    ⚠️ 拒绝进化: 类别退化超过阈值")
+                            print(f"    ⚠️ 拒绝进化: 类别退化超过阈值 (max_drop={max_drop:.2f})")
                             for cat, old_f1, new_f1, drop in regressions:
                                 print(f"      {cat}: {old_f1:.3f} → {new_f1:.3f} (↓{drop:.3f})")
                         else:
@@ -1239,8 +1263,8 @@ def main():
     parser.add_argument(
         "--max-category-drop",
         type=float,
-        default=0.15,
-        help="最大允许的单类别 F1 下降幅度 (default: 0.15)",
+        default=DEFAULT_MAX_CATEGORY_DROP,
+        help=f"最大允许的单类别 F1 下降幅度 (default: {DEFAULT_MAX_CATEGORY_DROP})",
     )
 
     args = parser.parse_args()

--- a/main.py
+++ b/main.py
@@ -1024,8 +1024,8 @@ class PrimeVulLayer1Pipeline:
                         old_cr = best_result.get("classification_report")
                         new_cr = eval_result.get("classification_report")
                         if not isinstance(old_cr, dict) or not isinstance(new_cr, dict):
-                            print("    [warn] classification_report missing or not a dict, skipping regression check")
-                            passed, regressions = True, []
+                            print("    [warn] classification_report missing or not a dict, rejecting candidate")
+                            passed, regressions = False, []
                         else:
                             passed, regressions = self._check_category_regression(
                                 old_cr, new_cr, max_drop,

--- a/main.py
+++ b/main.py
@@ -806,19 +806,21 @@ class PrimeVulLayer1Pipeline:
     ) -> Tuple[bool, List[Tuple[str, float, float, float]]]:
         """Check if any category F1 dropped more than max_drop.
 
-        Iterates over the union of categories present in both reports
-        (intersected with CWE_MAJOR_CATEGORIES) and logs when a category
-        is missing from either report.
+        Iterates over CWE_MAJOR_CATEGORIES plus any additional category
+        keys found in either report (excluding sklearn aggregates like
+        ``accuracy``, ``macro avg``, ``weighted avg``).  Categories
+        missing from one report are treated as having f1-score of 0.0.
 
         Returns (passed: bool, regressions: list of (category, old_f1, new_f1, drop))
         """
         regressions = []
-        # Use all known categories, but also check for unexpected ones in reports
-        all_categories = set(CWE_MAJOR_CATEGORIES)
-        for key in list(old_report.keys()) + list(new_report.keys()):
-            if isinstance(old_report.get(key), dict) or isinstance(new_report.get(key), dict):
-                if key not in all_categories and key not in ("accuracy", "macro avg", "weighted avg"):
-                    all_categories.add(key)
+        # Aggregate keys exclude list (sklearn classification_report aggregates)
+        _AGGREGATE_KEYS = {"accuracy", "macro avg", "weighted avg"}
+        all_categories = set(CWE_MAJOR_CATEGORIES) | {
+            k for k in set(old_report) | set(new_report)
+            if k not in _AGGREGATE_KEYS
+            and (isinstance(old_report.get(k), dict) or isinstance(new_report.get(k), dict))
+        }
 
         for cat in sorted(all_categories):
             old_entry = old_report.get(cat)

--- a/main.py
+++ b/main.py
@@ -439,7 +439,9 @@ class PromptEvolver:
 DEFAULT_MAX_CATEGORY_DROP = 0.15
 
 # sklearn classification_report aggregate keys that are not real categories
-_REPORT_AGGREGATE_KEYS = frozenset({"accuracy", "macro avg", "weighted avg", "micro avg"})
+_REPORT_AGGREGATE_KEYS = frozenset({
+    "accuracy", "macro avg", "weighted avg", "micro avg", "samples avg",
+})
 
 
 class PrimeVulLayer1Pipeline:
@@ -1019,11 +1021,15 @@ class PrimeVulLayer1Pipeline:
                     if evolved_individual.fitness > best_individual.fitness:
                         # Check for category regression before accepting
                         max_drop = self.config.get("max_category_drop", DEFAULT_MAX_CATEGORY_DROP)
-                        passed, regressions = self._check_category_regression(
-                            best_result["classification_report"],
-                            eval_result["classification_report"],
-                            max_drop,
-                        )
+                        old_cr = best_result.get("classification_report")
+                        new_cr = eval_result.get("classification_report")
+                        if not isinstance(old_cr, dict) or not isinstance(new_cr, dict):
+                            print("    [warn] classification_report missing or not a dict, skipping regression check")
+                            passed, regressions = True, []
+                        else:
+                            passed, regressions = self._check_category_regression(
+                                old_cr, new_cr, max_drop,
+                            )
                         if not passed:
                             print(f"    ⚠️ 拒绝进化: 类别退化超过阈值 (max_drop={max_drop:.2f})")
                             for cat, old_f1, new_f1, drop in regressions:

--- a/main.py
+++ b/main.py
@@ -812,10 +812,6 @@ class PrimeVulLayer1Pipeline:
 
         Returns (passed: bool, regressions: list of (category, old_f1, new_f1, drop))
         """
-        if not (0.0 <= max_drop <= 1.0):
-            raise ValueError(
-                f"max_drop must be between 0.0 and 1.0, got {max_drop}"
-            )
         regressions = []
         # Use all known categories, but also check for unexpected ones in reports
         all_categories = set(CWE_MAJOR_CATEGORIES)
@@ -1268,6 +1264,11 @@ def main():
     )
 
     args = parser.parse_args()
+
+    if not (0.0 <= args.max_category_drop <= 1.0):
+        parser.error(
+            f"--max-category-drop must be between 0.0 and 1.0, got {args.max_category_drop}"
+        )
 
     # 创建配置
     config = {


### PR DESCRIPTION
## Summary
- Adds `--max-category-drop` CLI flag (default `0.15`) to control the maximum allowed per-category F1 drop
- Adds `_check_category_regression()` method to `PrimeVulLayer1Pipeline` that compares per-category F1 scores between the current best and a candidate prompt
- Modifies the evolution acceptance logic: even if overall fitness improves, the candidate is rejected when any CWE category's F1 drops beyond the threshold

Prevents evolution from destroying minority categories while optimizing overall fitness. In ablation study, Memory Mgmt dropped from 0.444->0.071 and Integer Errors from 0.353->0.000 without being caught.

## Test plan
- [ ] Run `uv run python -m py_compile main.py` -- verified, passes
- [ ] Run a short evolution (`--max-generations 2`) and confirm regression messages appear when a category F1 drops
- [ ] Verify `--max-category-drop 0.0` rejects any regression, `--max-category-drop 1.0` effectively disables the guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

</details>

</details>

新功能：
- 添加 `max-category-drop` CLI 标志和配置项，用于在演化过程中限制任意单个 CWE 类别允许的 F1 降幅上限。
- 添加按类别的回归检查，在接受候选提示前，对当前最佳提示和候选提示的分类报告进行对比。

增强点：
- 更新演化接受逻辑，拒绝任何导致某一类别 F1 下降超过配置阈值的候选，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

</details>

</details>

</details>

新功能：
- 引入 `max-category-drop` CLI 标志和配置选项，用于控制演化过程中每个 CWE 类别允许的 F1 下降幅度。
- 添加类别级回归检查，在接受进化后的提示词之前，比对当前最佳提示词与候选提示词在各类别上的 F1 分数。

改进：
- 更新演化接受逻辑，拒绝任何使某个类别 F1 下降超过配置阈值的候选方案，同时仍会记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

</details>

</details>

新功能：
- 添加 `max-category-drop` CLI 标志和配置项，用于在演化过程中限制任意单个 CWE 类别允许的 F1 降幅上限。
- 添加按类别的回归检查，在接受候选提示前，对当前最佳提示和候选提示的分类报告进行对比。

增强点：
- 更新演化接受逻辑，拒绝任何导致某一类别 F1 下降超过配置阈值的候选，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

新功能：
- 引入 `--max-category-drop` CLI 标志和配置项，用于在 evolution 过程中限制任一单独类别允许的 F1 降幅。

增强内容：
- 在当前最优和候选分类报告之间增加按类别的回归检查，并利用该检查阻止超过已配置 F1 降幅阈值的 evolution 步骤，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

在进化流程中添加可配置的按类别 F1 回归保护机制，并将其集成到提示选择中。

新功能：
- 引入 `--max-category-drop` CLI 参数和配置选项，用于限定进化过程中任一单个类别允许的 F1 降幅上限。
- 添加按类别的回归检查，用于比较当前最佳提示与候选提示之间的分类报告。

增强改进：
- 更新进化接受逻辑，拒绝那些类别 F1 降幅超过配置阈值的候选项，同时提供详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在进化流程中添加可配置的按类别 F1 回归保护机制，以防止在整体适应度提升的情况下仍然接受对任意 CWE 类别造成显著退化的提示。

新功能：
- 引入带有校验机制的 `--max-category-drop` CLI 选项和配置值，用于限制进化过程中任一单一类别允许的 F1 降幅。

改进：
- 基于分类报告添加按类别的 F1 回归检查，并将其集成到进化的接受逻辑中；当候选超过配置的降幅阈值时拒绝其被接受，同时记录详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在提示进化流水线中强制执行可配置的按类别 F1 回归保护机制，以防止在少数 CWE 类别上出现有害的性能下降。

New Features:
- 添加 `--max-category-drop` CLI 选项和配置值，用于限定在进化过程中任一类别允许的 F1 降幅上限。
- 引入按类别的回归检查，用于比较当前最佳与候选分类报告之间的各类别 F1 分数。

Enhancements:
- 更新进化结果接受逻辑：即使整体适应度有所提升，如果候选结果在任一类别上的 F1 降幅超过配置阈值，也会被拒绝，并在日志中输出详细的回归信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a configurable per-category F1 regression guard in the prompt evolution pipeline to prevent harmful drops in minority CWE categories.

New Features:
- Add a --max-category-drop CLI option and config value to bound the allowed F1 decrease for any single category during evolution.
- Introduce a per-category regression check that compares F1 scores between the current best and candidate classification reports.

Enhancements:
- Update evolution acceptance logic to reject candidates that exceed the configured per-category F1 drop threshold, even if overall fitness improves, and surface detailed regression information in logs.

</details>

</details>

</details>

</details>

</details>

</details>

</details>

</details>

</details>