### PR TITLE
feat: make MulVul agent count adaptive

### DIFF
--- a/scripts/demo_mulvul.py
+++ b/scripts/demo_mulvul.py
@@ -25,8 +25,9 @@ def demo_mulvul():
     detector = MulVulDetector.create_default(
         llm_client=llm_client,
         retriever=None,  # No RAG for demo
-        k=3,
+        max_agents=3,
         parallel=True,
+        adaptive=True,
     )
 
     # Test cases
@@ -90,7 +91,8 @@ def main():
 
         # Print routing info
         print(f"\n🔀 Router Agent:")
-        print(f"   Top-k categories: {details['routing']['top_k']}")
+        print(f"   Ranked categories: {details['routing']['ranked']}")
+        print(f"   Selected detector categories: {details['routing']['selected']}")
 
         # Print detector results
         print(f"\n🔍 Detector Results:")

--- a/scripts/run_mulvul_cwe_eval.py
+++ b/scripts/run_mulvul_cwe_eval.py
@@ -118,10 +118,11 @@ def run_cwe_evaluation(
     max_workers: int = 32,
     max_samples: Optional[int] = None,
     output_dir: str = "./outputs",
-    k: int = 3,
+    max_agents: int = 3,
     balanced: bool = False,
     seed: int = 42,
     kb_path: str = None,
+    adaptive_agents: bool = True,
 ) -> Dict[str, Any]:
     """运行 CWE 级别评估"""
 
@@ -130,7 +131,8 @@ def run_cwe_evaluation(
     print("=" * 70)
     print("🔥 MulVul CWE 级别评估")
     print("=" * 70)
-    print(f"   🔀 Router: Top-{k} routing")
+    routing_mode = "Adaptive" if adaptive_agents else "Fixed"
+    print(f"   🔀 Router: {routing_mode} routing (max_agents={max_agents})")
     print(f"   📊 评估层级: Major → Middle → CWE")
     if kb_path:
         print(f"   📚 Knowledge Base: {kb_path}")
@@ -189,7 +191,13 @@ def run_cwe_evaluation(
         def evaluate_with_detector(args):
             item, expected = args
             llm_client = create_llm_client()
-            detector = MulVulDetector.create_default(llm_client, retriever=retriever, k=k, parallel=False)
+            detector = MulVulDetector.create_default(
+                llm_client,
+                retriever=retriever,
+                max_agents=max_agents,
+                parallel=False,
+                adaptive=adaptive_agents,
+            )
             return evaluate_single_sample(item, detector, expected)
 
         futures = {
@@ -227,7 +235,7 @@ def run_cwe_evaluation(
     print("📊 CWE 级别评估结果")
     print("=" * 70)
 
-    print(f"\n🔀 Router (Recall@{k}): {routing_correct/total:.2%} ({routing_correct}/{total})")
+    print(f"\n🔀 Router (Recall@{max_agents}): {routing_correct/total:.2%} ({routing_correct}/{total})")
     print(f"🎯 Major Accuracy: {major_correct/total:.2%} ({major_correct}/{total})")
     print(f"🎯 CWE Accuracy: {cwe_correct/total:.2%} ({cwe_correct}/{total})")
 
@@ -246,7 +254,9 @@ def run_cwe_evaluation(
     summary = {
         "timestamp": datetime.now().isoformat(),
         "data_file": data_file,
-        "k": k,
+        "k": max_agents,
+        "max_agents": max_agents,
+        "adaptive_agents": adaptive_agents,
         "total_samples": total,
         "elapsed_seconds": elapsed,
         "routing_recall_k": routing_correct / total,
@@ -269,7 +279,19 @@ def main():
     parser.add_argument("--workers", type=int, default=32)
     parser.add_argument("--max-samples", type=int, default=None)
     parser.add_argument("--output", default="./outputs")
-    parser.add_argument("--k", type=int, default=3, help="Top-k routing")
+    parser.add_argument(
+        "--max-agents",
+        "--k",
+        dest="max_agents",
+        type=int,
+        default=3,
+        help="Adaptive routing的最大 detector agent 数",
+    )
+    parser.add_argument(
+        "--fixed-agents",
+        action="store_true",
+        help="禁用自适应 routing，始终运行 max_agents 个 detector",
+    )
     parser.add_argument("--balanced", action="store_true", help="Balance benign:vul = 1:1")
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--kb", default="./data/knowledge_base_hierarchical.json", help="Knowledge base path")
@@ -285,10 +307,11 @@ def main():
         max_workers=args.workers,
         max_samples=args.max_samples,
         output_dir=args.output,
-        k=args.k,
+        max_agents=args.max_agents,
         balanced=args.balanced,
         seed=args.seed,
         kb_path=args.kb,
+        adaptive_agents=not args.fixed_agents,
     )
     return 0
 

--- a/scripts/run_mulvul_eval.py
+++ b/scripts/run_mulvul_eval.py
@@ -2,7 +2,7 @@
 """MulVul 多智能体系统评估脚本
 
 使用完整的 Router-Detector-Aggregator 架构:
-- RouterAgent: Top-k 路由 + 跨类型对比检索
+- RouterAgent: 自适应路由 + 跨类型对比检索
 - DetectorAgent: 类别专用检测器
 - DecisionAggregator: 置信度加权聚合
 - Recall@k / F1 评估指标
@@ -164,10 +164,11 @@ def run_mulvul_evaluation(
     max_workers: int = 32,
     max_samples: Optional[int] = None,
     output_dir: str = "./outputs",
-    k: int = 3,
+    max_agents: int = 3,
     balanced: bool = False,
     seed: int = None,
     kb_path: str = None,
+    adaptive_agents: bool = True,
 ) -> Dict[str, Any]:
     """运行 MulVul 多智能体评估"""
 
@@ -176,7 +177,8 @@ def run_mulvul_evaluation(
     print("=" * 70)
     print("🔥 MulVul 多智能体系统评估")
     print("=" * 70)
-    print(f"   🔀 Router: Top-{k} routing")
+    routing_mode = "Adaptive" if adaptive_agents else "Fixed"
+    print(f"   🔀 Router: {routing_mode} routing (max_agents={max_agents})")
     print(f"   🔍 Detectors: Category-specific (Memory/Injection/Logic/Input/Crypto)")
     print(f"   📊 Aggregator: Confidence-based")
     if balanced:
@@ -220,7 +222,7 @@ def run_mulvul_evaluation(
     print(f"\n🚀 启动并发评估 (workers={max_workers})")
 
     # 统计结构
-    router_metrics = RouterMetrics(k=k)
+    router_metrics = RouterMetrics(k=max_agents)
     detector_metrics = MultiClassMetrics()
     major_stats = defaultdict(lambda: {"total": 0, "routing_correct": 0, "final_correct": 0})
 
@@ -233,7 +235,13 @@ def run_mulvul_evaluation(
         def evaluate_with_detector(args):
             item, expected_major = args
             llm_client = create_llm_client()
-            detector = MulVulDetector.create_default(llm_client, retriever=retriever, k=k, parallel=False)
+            detector = MulVulDetector.create_default(
+                llm_client,
+                retriever=retriever,
+                max_agents=max_agents,
+                parallel=False,
+                adaptive=adaptive_agents,
+            )
             return evaluate_single_sample(item, detector, expected_major)
 
         futures = {
@@ -293,8 +301,8 @@ def run_mulvul_evaluation(
     print("📊 MulVul 评估结果")
     print("=" * 70)
 
-    print(f"\n🔀 Router Agent (Top-{k} Routing):")
-    print(f"   Recall@{k}: {recall_k:.2%} ({routing_correct}/{total})")
+    print(f"\n🔀 Router Agent ({routing_mode}, max_agents={max_agents}):")
+    print(f"   Recall@{max_agents}: {recall_k:.2%} ({routing_correct}/{total})")
     router_report = router_metrics.get_report()
     print(f"   MRR: {router_report['mrr']:.4f}")
 
@@ -322,7 +330,9 @@ def run_mulvul_evaluation(
     summary = {
         "timestamp": datetime.now().isoformat(),
         "data_file": data_file,
-        "k": k,
+        "k": max_agents,
+        "max_agents": max_agents,
+        "adaptive_agents": adaptive_agents,
         "total_samples": total,
         "elapsed_seconds": elapsed,
         "router": {
@@ -351,7 +361,19 @@ def main():
     parser.add_argument("--workers", type=int, default=32)
     parser.add_argument("--max-samples", type=int, default=None)
     parser.add_argument("--output", default="./outputs")
-    parser.add_argument("--k", type=int, default=3, help="Top-k routing")
+    parser.add_argument(
+        "--max-agents",
+        "--k",
+        dest="max_agents",
+        type=int,
+        default=3,
+        help="Adaptive routing的最大 detector agent 数",
+    )
+    parser.add_argument(
+        "--fixed-agents",
+        action="store_true",
+        help="禁用自适应 routing，始终运行 max_agents 个 detector",
+    )
     parser.add_argument("--epochs", type=int, default=1, help="Number of evaluation runs")
     parser.add_argument("--balanced", action="store_true", help="Balance benign:vul = 1:1")
     parser.add_argument("--seed", type=int, default=42, help="Random seed for balanced sampling")
@@ -375,10 +397,11 @@ def main():
             max_workers=args.workers,
             max_samples=args.max_samples,
             output_dir=args.output,
-            k=args.k,
+            max_agents=args.max_agents,
             balanced=args.balanced,
             seed=args.seed + epoch if args.balanced else None,
             kb_path=args.kb,
+            adaptive_agents=not args.fixed_agents,
         )
         all_results.append(summary)
 

--- a/src/evoprompt/agents/base.py
+++ b/src/evoprompt/agents/base.py
@@ -45,7 +45,7 @@ class DetectionResult:
 
 @dataclass
 class RoutingResult:
-    """Result from Router Agent with top-k categories."""
+    """Result from Router Agent with ranked categories."""
 
     categories: List[tuple]  # [(category, confidence), ...]
     evidence_used: List[dict] = field(default_factory=list)
@@ -59,5 +59,7 @@ class RoutingResult:
     def top_confidence(self) -> float:
         return self.categories[0][1] if self.categories else 0.0
 
-    def get_top_k(self, k: int = 3) -> List[tuple]:
+    def get_top_k(self, k: Optional[int] = None) -> List[tuple]:
+        if k is None:
+            return list(self.categories)
         return self.categories[:k]

--- a/src/evoprompt/agents/base.py
+++ b/src/evoprompt/agents/base.py
@@ -3,6 +3,9 @@
 from dataclasses import dataclass, field
 from typing import Optional, List
 
+BENIGN_CATEGORY = "Benign"
+UNKNOWN_CATEGORY = "Unknown"
+
 
 @dataclass
 class DetectionResult:
@@ -29,7 +32,12 @@ class DetectionResult:
 
     def is_vulnerable(self) -> bool:
         """Check if prediction indicates vulnerability."""
-        return self.prediction.lower() not in ("benign", "safe", "non-vul", "non-vulnerable")
+        return self.prediction.lower() not in (
+            BENIGN_CATEGORY.lower(),
+            "safe",
+            "non-vul",
+            "non-vulnerable",
+        )
 
     def to_dict(self) -> dict:
         return {
@@ -53,7 +61,7 @@ class RoutingResult:
 
     @property
     def top_category(self) -> str:
-        return self.categories[0][0] if self.categories else "Unknown"
+        return self.categories[0][0] if self.categories else UNKNOWN_CATEGORY
 
     @property
     def top_confidence(self) -> float:

--- a/src/evoprompt/agents/mulvul.py
+++ b/src/evoprompt/agents/mulvul.py
@@ -6,8 +6,8 @@ Implements the complete detection pipeline from method.md Algorithm 3:
 3. Stage III: Decision Aggregation
 """
 
-from typing import Dict, List, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Dict, List, Optional, Tuple
 
 from .base import DetectionResult, RoutingResult
 from .router_agent import RouterAgent
@@ -77,27 +77,14 @@ class MulVulDetector:
         Returns:
             DetectionResult with prediction, confidence, and evidence
         """
-        # Stage I: Routing
         routing_result = self.router.route(code)
-        selected_categories = self._select_detector_categories(routing_result)
-
-        if not selected_categories:
-            return self._handle_empty_selection(routing_result)
-
-        # Stage II: Detection
-        if self.parallel:
-            results = self._detect_parallel(code, selected_categories)
-        else:
-            results = self._detect_sequential(code, selected_categories)
-
-        # Stage III: Aggregation
-        final_result = self.aggregator.aggregate(results)
-
-        # Add routing info to result
-        final_result.raw_response = (
-            f"Selected detectors: {[c[0] for c in selected_categories]}\n"
-            f"Router ranking: {[c[0] for c in routing_result.categories]}\n"
-            f"{final_result.raw_response}"
+        selected_categories, _, final_result = self._run_detection(
+            code, routing_result
+        )
+        final_result.raw_response = self._format_raw_response(
+            selected_categories,
+            routing_result,
+            final_result.raw_response,
         )
 
         return final_result
@@ -108,24 +95,14 @@ class MulVulDetector:
         Returns:
             Dict with routing, detection, and aggregation details
         """
-        # Stage I: Routing
         routing_result = self.router.route(code)
-        selected_categories = self._select_detector_categories(routing_result)
-
-        # Stage II: Detection
-        if not selected_categories:
-            final_result = self._handle_empty_selection(routing_result)
-            detector_results = []
-        elif self.parallel:
-            detector_results = self._detect_parallel(code, selected_categories)
-            final_result = self.aggregator.aggregate(detector_results)
-        else:
-            detector_results = self._detect_sequential(code, selected_categories)
-            final_result = self.aggregator.aggregate(detector_results)
+        selected_categories, detector_results, final_result = self._run_detection(
+            code, routing_result
+        )
 
         return {
             "routing": {
-                "top_k": selected_categories,
+                "top_k": routing_result.get_top_k(self.max_agents),
                 "ranked": routing_result.categories,
                 "selected": selected_categories,
                 "selected_agent_count": len(selected_categories),
@@ -145,12 +122,7 @@ class MulVulDetector:
         mode is enabled, specialist detector fan-out expands only when the
         router remains uncertain about the vulnerable category.
         """
-        ranked_categories = routing_result.get_top_k()
-        vulnerable_categories = [
-            (category, confidence)
-            for category, confidence in ranked_categories
-            if category in self.detectors
-        ]
+        vulnerable_categories = self._filter_supported_categories(routing_result)
 
         if not vulnerable_categories:
             return []
@@ -158,46 +130,70 @@ class MulVulDetector:
         if not self.adaptive:
             return vulnerable_categories[:self.max_agents]
 
-        top_category = routing_result.top_category
-        top_confidence = routing_result.top_confidence
-        top_vulnerable_confidence = vulnerable_categories[0][1]
-
-        if (
-            top_category == "Benign"
-            and top_confidence >= self.benign_short_circuit_threshold
-            and top_vulnerable_confidence
-            < top_confidence * self.routing_relative_threshold
+        if self._should_short_circuit_benign(
+            routing_result, vulnerable_categories
         ):
             return []
 
+        selected = self._apply_dynamic_threshold(vulnerable_categories)
+        if not selected or len(selected) < self.min_agents:
+            return self._fallback_min_vulnerable(vulnerable_categories)
+
+        return selected
+
+    def _filter_supported_categories(
+        self,
+        routing_result: RoutingResult,
+    ) -> List[tuple]:
+        """Keep only categories backed by specialist detectors."""
+        return [
+            (category, confidence)
+            for category, confidence in routing_result.get_top_k()
+            if category in self.detectors
+        ]
+
+    def _should_short_circuit_benign(
+        self,
+        routing_result: RoutingResult,
+        vulnerable_categories: List[tuple],
+    ) -> bool:
+        """Return True when a Benign router result should skip specialists."""
+        top_vulnerable_confidence = vulnerable_categories[0][1]
+        return (
+            routing_result.top_category == "Benign"
+            and routing_result.top_confidence
+            >= self.benign_short_circuit_threshold
+            and top_vulnerable_confidence
+            < routing_result.top_confidence * self.routing_relative_threshold
+        )
+
+    def _apply_dynamic_threshold(
+        self,
+        vulnerable_categories: List[tuple],
+    ) -> List[tuple]:
+        """Select competitive vulnerable categories under the adaptive policy."""
+        top_vulnerable_confidence = vulnerable_categories[0][1]
         dynamic_threshold = max(
             self.routing_confidence_threshold,
             top_vulnerable_confidence * self.routing_relative_threshold,
         )
-
-        selected = [
+        return [
             (category, confidence)
             for category, confidence in vulnerable_categories
             if confidence >= dynamic_threshold
         ][:self.max_agents]
 
-        if not selected:
-            min_required = min(
-                len(vulnerable_categories),
-                self.max_agents,
-                self.min_agents,
-            )
-            return vulnerable_categories[:min_required]
-
-        if len(selected) < self.min_agents:
-            min_required = min(
-                len(vulnerable_categories),
-                self.max_agents,
-                self.min_agents,
-            )
-            return vulnerable_categories[:min_required]
-
-        return selected
+    def _fallback_min_vulnerable(
+        self,
+        vulnerable_categories: List[tuple],
+    ) -> List[tuple]:
+        """Fallback to the highest-ranked vulnerable categories."""
+        min_required = min(
+            len(vulnerable_categories),
+            self.max_agents,
+            self.min_agents,
+        )
+        return vulnerable_categories[:min_required]
 
     def _handle_empty_selection(
         self,
@@ -208,10 +204,7 @@ class MulVulDetector:
             return DetectionResult(
                 prediction="Benign",
                 confidence=routing_result.top_confidence,
-                evidence=(
-                    "Router predicted Benign with high confidence, so no "
-                    "specialist detector was invoked."
-                ),
+                evidence="Router predicted Benign, so no specialist detector was invoked.",
                 category="Benign",
                 agent_id="router_benign",
                 raw_response=routing_result.raw_response,
@@ -223,6 +216,37 @@ class MulVulDetector:
             evidence="Router did not return any supported detector category.",
             agent_id="router_empty",
             raw_response=routing_result.raw_response,
+        )
+
+    def _run_detection(
+        self,
+        code: str,
+        routing_result: RoutingResult,
+    ) -> Tuple[List[tuple], List[DetectionResult], DetectionResult]:
+        """Execute detector fan-out and aggregation for one routed sample."""
+        selected_categories = self._select_detector_categories(routing_result)
+        if not selected_categories:
+            return [], [], self._handle_empty_selection(routing_result)
+
+        if self.parallel:
+            detector_results = self._detect_parallel(code, selected_categories)
+        else:
+            detector_results = self._detect_sequential(code, selected_categories)
+
+        final_result = self.aggregator.aggregate(detector_results)
+        return selected_categories, detector_results, final_result
+
+    def _format_raw_response(
+        self,
+        selected_categories: List[tuple],
+        routing_result: RoutingResult,
+        raw_response: str,
+    ) -> str:
+        """Attach routing metadata to the final raw response."""
+        return (
+            f"Selected detectors: {[c[0] for c in selected_categories]}\n"
+            f"Router ranking: {[c[0] for c in routing_result.categories]}\n"
+            f"{raw_response}"
         )
 
     def _detect_parallel(

--- a/src/evoprompt/agents/mulvul.py
+++ b/src/evoprompt/agents/mulvul.py
@@ -9,7 +9,12 @@ Implements the complete detection pipeline from method.md Algorithm 3:
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Dict, List, Optional, Tuple
 
-from .base import DetectionResult, RoutingResult
+from .base import (
+    BENIGN_CATEGORY,
+    UNKNOWN_CATEGORY,
+    DetectionResult,
+    RoutingResult,
+)
 from .router_agent import RouterAgent
 from .detector_agent import DetectorAgent, DetectorAgentFactory
 from .aggregator import DecisionAggregator
@@ -160,7 +165,7 @@ class MulVulDetector:
         """Return True when a Benign router result should skip specialists."""
         top_vulnerable_confidence = vulnerable_categories[0][1]
         return (
-            routing_result.top_category == "Benign"
+            routing_result.top_category == BENIGN_CATEGORY
             and routing_result.top_confidence
             >= self.benign_short_circuit_threshold
             and top_vulnerable_confidence
@@ -188,11 +193,8 @@ class MulVulDetector:
         vulnerable_categories: List[tuple],
     ) -> List[tuple]:
         """Fallback to the highest-ranked vulnerable categories."""
-        min_required = min(
-            len(vulnerable_categories),
-            self.max_agents,
-            self.min_agents,
-        )
+        max_possible = min(len(vulnerable_categories), self.max_agents)
+        min_required = min(max_possible, max(self.min_agents, 1))
         return vulnerable_categories[:min_required]
 
     def _handle_empty_selection(
@@ -200,20 +202,24 @@ class MulVulDetector:
         routing_result: RoutingResult,
     ) -> DetectionResult:
         """Handle cases where no specialist detector should be invoked."""
-        if routing_result.top_category == "Benign":
+        if routing_result.top_category == BENIGN_CATEGORY:
             return DetectionResult(
-                prediction="Benign",
+                prediction=BENIGN_CATEGORY,
                 confidence=routing_result.top_confidence,
-                evidence="Router predicted Benign, so no specialist detector was invoked.",
-                category="Benign",
+                evidence=(
+                    "Router predicted Benign, so no specialist detector "
+                    "was invoked."
+                ),
+                category=BENIGN_CATEGORY,
                 agent_id="router_benign",
                 raw_response=routing_result.raw_response,
             )
 
         return DetectionResult(
-            prediction="Unknown",
+            prediction=UNKNOWN_CATEGORY,
             confidence=0.0,
             evidence="Router did not return any supported detector category.",
+            category=UNKNOWN_CATEGORY,
             agent_id="router_empty",
             raw_response=routing_result.raw_response,
         )

--- a/src/evoprompt/agents/mulvul.py
+++ b/src/evoprompt/agents/mulvul.py
@@ -19,8 +19,8 @@ class MulVulDetector:
     """Complete MulVul detection pipeline.
 
     Implements Router-Detector architecture:
-    - Router predicts top-k categories
-    - Only relevant Detectors are invoked
+    - Router predicts ranked categories
+    - Detector fan-out adapts to router confidence
     - Results are aggregated by confidence
     """
 
@@ -30,7 +30,12 @@ class MulVulDetector:
         detectors: Dict[str, DetectorAgent],
         aggregator: DecisionAggregator = None,
         parallel: bool = True,
-        k: int = 3,
+        max_agents: int = 3,
+        adaptive: bool = True,
+        min_agents: int = 1,
+        routing_confidence_threshold: float = 0.2,
+        routing_relative_threshold: float = 0.6,
+        benign_short_circuit_threshold: float = 0.8,
     ):
         """Initialize MulVul detector.
 
@@ -39,13 +44,29 @@ class MulVulDetector:
             detectors: Dict of category -> DetectorAgent
             aggregator: Decision aggregator (default: confidence-based)
             parallel: Whether to run detectors in parallel
-            k: Number of top categories to route to
+            max_agents: Maximum number of detector agents to invoke
+            adaptive: Whether to adapt detector fan-out using router confidence
+            min_agents: Minimum number of detector agents to invoke when not
+                short-circuiting to Benign
+            routing_confidence_threshold: Absolute minimum confidence for
+                adaptive detector fan-out
+            routing_relative_threshold: Relative threshold against the highest
+                vulnerable category confidence for adaptive fan-out
+            benign_short_circuit_threshold: If Benign is the top route and is
+                this confident, skip specialist detectors unless a vulnerable
+                category remains competitive
         """
         self.router = router
         self.detectors = detectors
         self.aggregator = aggregator or DecisionAggregator()
         self.parallel = parallel
-        self.k = k
+        self.max_agents = max(1, max_agents)
+        self.k = self.max_agents
+        self.adaptive = adaptive
+        self.min_agents = max(1, min_agents)
+        self.routing_confidence_threshold = routing_confidence_threshold
+        self.routing_relative_threshold = routing_relative_threshold
+        self.benign_short_circuit_threshold = benign_short_circuit_threshold
 
     def detect(self, code: str) -> DetectionResult:
         """Detect vulnerability in code.
@@ -58,19 +79,26 @@ class MulVulDetector:
         """
         # Stage I: Routing
         routing_result = self.router.route(code)
-        top_k_categories = routing_result.get_top_k(self.k)
+        selected_categories = self._select_detector_categories(routing_result)
+
+        if not selected_categories:
+            return self._handle_empty_selection(routing_result)
 
         # Stage II: Detection
         if self.parallel:
-            results = self._detect_parallel(code, top_k_categories)
+            results = self._detect_parallel(code, selected_categories)
         else:
-            results = self._detect_sequential(code, top_k_categories)
+            results = self._detect_sequential(code, selected_categories)
 
         # Stage III: Aggregation
         final_result = self.aggregator.aggregate(results)
 
         # Add routing info to result
-        final_result.raw_response = f"Routed to: {[c[0] for c in top_k_categories]}\n{final_result.raw_response}"
+        final_result.raw_response = (
+            f"Selected detectors: {[c[0] for c in selected_categories]}\n"
+            f"Router ranking: {[c[0] for c in routing_result.categories]}\n"
+            f"{final_result.raw_response}"
+        )
 
         return final_result
 
@@ -82,31 +110,129 @@ class MulVulDetector:
         """
         # Stage I: Routing
         routing_result = self.router.route(code)
-        top_k_categories = routing_result.get_top_k(self.k)
+        selected_categories = self._select_detector_categories(routing_result)
 
         # Stage II: Detection
-        if self.parallel:
-            detector_results = self._detect_parallel(code, top_k_categories)
+        if not selected_categories:
+            final_result = self._handle_empty_selection(routing_result)
+            detector_results = []
+        elif self.parallel:
+            detector_results = self._detect_parallel(code, selected_categories)
+            final_result = self.aggregator.aggregate(detector_results)
         else:
-            detector_results = self._detect_sequential(code, top_k_categories)
-
-        # Stage III: Aggregation
-        final_result = self.aggregator.aggregate(detector_results)
+            detector_results = self._detect_sequential(code, selected_categories)
+            final_result = self.aggregator.aggregate(detector_results)
 
         return {
             "routing": {
-                "top_k": top_k_categories,
+                "top_k": selected_categories,
+                "ranked": routing_result.categories,
+                "selected": selected_categories,
+                "selected_agent_count": len(selected_categories),
                 "evidence_count": len(routing_result.evidence_used),
             },
             "detectors": [r.to_dict() for r in detector_results],
             "final": final_result.to_dict(),
         }
 
+    def _select_detector_categories(
+        self,
+        routing_result: RoutingResult,
+    ) -> List[tuple]:
+        """Select detector categories from router output.
+
+        The router returns a ranked list across all categories. When adaptive
+        mode is enabled, specialist detector fan-out expands only when the
+        router remains uncertain about the vulnerable category.
+        """
+        ranked_categories = routing_result.get_top_k()
+        vulnerable_categories = [
+            (category, confidence)
+            for category, confidence in ranked_categories
+            if category in self.detectors
+        ]
+
+        if not vulnerable_categories:
+            return []
+
+        if not self.adaptive:
+            return vulnerable_categories[:self.max_agents]
+
+        top_category = routing_result.top_category
+        top_confidence = routing_result.top_confidence
+        top_vulnerable_confidence = vulnerable_categories[0][1]
+
+        if (
+            top_category == "Benign"
+            and top_confidence >= self.benign_short_circuit_threshold
+            and top_vulnerable_confidence
+            < top_confidence * self.routing_relative_threshold
+        ):
+            return []
+
+        dynamic_threshold = max(
+            self.routing_confidence_threshold,
+            top_vulnerable_confidence * self.routing_relative_threshold,
+        )
+
+        selected = [
+            (category, confidence)
+            for category, confidence in vulnerable_categories
+            if confidence >= dynamic_threshold
+        ][:self.max_agents]
+
+        if not selected:
+            min_required = min(
+                len(vulnerable_categories),
+                self.max_agents,
+                self.min_agents,
+            )
+            return vulnerable_categories[:min_required]
+
+        if len(selected) < self.min_agents:
+            min_required = min(
+                len(vulnerable_categories),
+                self.max_agents,
+                self.min_agents,
+            )
+            return vulnerable_categories[:min_required]
+
+        return selected
+
+    def _handle_empty_selection(
+        self,
+        routing_result: RoutingResult,
+    ) -> DetectionResult:
+        """Handle cases where no specialist detector should be invoked."""
+        if routing_result.top_category == "Benign":
+            return DetectionResult(
+                prediction="Benign",
+                confidence=routing_result.top_confidence,
+                evidence=(
+                    "Router predicted Benign with high confidence, so no "
+                    "specialist detector was invoked."
+                ),
+                category="Benign",
+                agent_id="router_benign",
+                raw_response=routing_result.raw_response,
+            )
+
+        return DetectionResult(
+            prediction="Unknown",
+            confidence=0.0,
+            evidence="Router did not return any supported detector category.",
+            agent_id="router_empty",
+            raw_response=routing_result.raw_response,
+        )
+
     def _detect_parallel(
         self, code: str, categories: List[tuple]
     ) -> List[DetectionResult]:
         """Run detectors in parallel."""
         results = []
+
+        if not categories:
+            return results
 
         with ThreadPoolExecutor(max_workers=len(categories)) as executor:
             futures = {}
@@ -160,24 +286,34 @@ class MulVulDetector:
         cls,
         llm_client,
         retriever=None,
-        k: int = 3,
+        max_agents: int = 3,
         parallel: bool = True,
+        adaptive: bool = True,
+        k: Optional[int] = None,
+        min_agents: int = 1,
+        routing_confidence_threshold: float = 0.2,
+        routing_relative_threshold: float = 0.6,
+        benign_short_circuit_threshold: float = 0.8,
     ) -> "MulVulDetector":
         """Create MulVul detector with default configuration.
 
         Args:
             llm_client: LLM client for all agents
             retriever: Optional retriever for evidence
-            k: Number of top categories
+            max_agents: Maximum number of detector agents
             parallel: Whether to run detectors in parallel
+            adaptive: Whether to adapt detector fan-out using router confidence
+            k: Backward-compatible alias for max_agents
 
         Returns:
             Configured MulVulDetector instance
         """
+        if k is not None:
+            max_agents = k
+
         router = RouterAgent(
             llm_client=llm_client,
             retriever=retriever,
-            k=k,
         )
 
         detectors = DetectorAgentFactory.create_all_detectors(
@@ -192,5 +328,10 @@ class MulVulDetector:
             detectors=detectors,
             aggregator=aggregator,
             parallel=parallel,
-            k=k,
+            max_agents=max_agents,
+            adaptive=adaptive,
+            min_agents=min_agents,
+            routing_confidence_threshold=routing_confidence_threshold,
+            routing_relative_threshold=routing_relative_threshold,
+            benign_short_circuit_threshold=benign_short_circuit_threshold,
         )

--- a/src/evoprompt/agents/router_agent.py
+++ b/src/evoprompt/agents/router_agent.py
@@ -1,9 +1,9 @@
-"""Router Agent for top-k category routing.
+"""Router Agent for ranked category routing.
 
 Implements Stage I from method.md Algorithm 3:
 1. Convert code to SCALE representation T(x)
 2. Retrieve cross-type contrastive evidence from K
-3. Predict top-k categories with confidence scores
+3. Predict ranked categories with confidence scores
 """
 
 import json
@@ -17,7 +17,10 @@ MAJOR_CATEGORIES = ["Memory", "Injection", "Logic", "Input", "Crypto", "Benign"]
 
 DEFAULT_ROUTER_PROMPT = """You are a security expert routing code to specialized vulnerability detectors.
 
-Analyze the code and predict the TOP-3 most likely vulnerability categories.
+Analyze the code and rank the vulnerability categories by likelihood.
+Return as many categories as needed (1-6) in descending confidence order.
+If the code appears benign, include "Benign" with the highest confidence, but
+still include any plausible vulnerable alternatives with lower confidence.
 
 ## Categories:
 - Memory: Buffer overflow, use-after-free, null pointer, integer overflow
@@ -39,8 +42,8 @@ Analyze the code and predict the TOP-3 most likely vulnerability categories.
 {{
   "predictions": [
     {{"category": "Memory", "confidence": 0.85, "reason": "Buffer operations without bounds checking"}},
-    {{"category": "Benign", "confidence": 0.10, "reason": "Could be safe if inputs are validated"}},
-    {{"category": "Injection", "confidence": 0.05, "reason": "No obvious injection points"}}
+    {{"category": "Injection", "confidence": 0.55, "reason": "Untrusted input may reach a query or command"}},
+    {{"category": "Benign", "confidence": 0.10, "reason": "Could still be safe if validation is present"}}
   ]
 }}
 
@@ -48,7 +51,7 @@ Respond with ONLY the JSON object."""
 
 
 class RouterAgent:
-    """Routes code to top-k most relevant Detector Agents.
+    """Routes code to ranked Detector Agents.
 
     Uses cross-type contrastive retrieval to provide evidence
     spanning multiple vulnerability categories.
@@ -59,23 +62,23 @@ class RouterAgent:
         llm_client,
         retriever=None,
         prompt: str = DEFAULT_ROUTER_PROMPT,
-        k: int = 3,
+        max_candidates: Optional[int] = None,
         categories: List[str] = None,
     ):
         self.llm_client = llm_client
         self.retriever = retriever
         self.prompt = prompt
-        self.k = k
+        self.max_candidates = max_candidates
         self.categories = categories or MAJOR_CATEGORIES
 
     def route(self, code: str) -> RoutingResult:
-        """Route code to top-k categories.
+        """Route code to ranked categories.
 
         Args:
             code: Source code to analyze
 
         Returns:
-            RoutingResult with top-k categories and confidence scores
+            RoutingResult with ranked categories and confidence scores
         """
         # 1. Retrieve cross-type contrastive evidence
         evidence = self._retrieve_contrastive_evidence(code)
@@ -89,9 +92,11 @@ class RouterAgent:
 
         # 4. Parse response
         categories = self._parse_response(response)
+        if self.max_candidates is not None:
+            categories = categories[:self.max_candidates]
 
         return RoutingResult(
-            categories=categories[:self.k],
+            categories=categories,
             evidence_used=evidence,
             raw_response=response,
         )
@@ -134,10 +139,19 @@ class RouterAgent:
             if json_match:
                 data = json.loads(json_match.group())
                 predictions = data.get("predictions", [])
-                return [
-                    (p.get("category", "Unknown"), float(p.get("confidence", 0.5)))
-                    for p in predictions
-                ]
+                parsed = []
+                seen = set()
+                for prediction in predictions:
+                    category = prediction.get("category", "Unknown")
+                    if category not in self.categories or category in seen:
+                        continue
+                    parsed.append(
+                        (category, float(prediction.get("confidence", 0.5)))
+                    )
+                    seen.add(category)
+
+                if parsed:
+                    return sorted(parsed, key=lambda item: item[1], reverse=True)
         except (json.JSONDecodeError, ValueError):
             pass
 

--- a/src/evoprompt/agents/router_agent.py
+++ b/src/evoprompt/agents/router_agent.py
@@ -139,16 +139,15 @@ class RouterAgent:
             if json_match:
                 data = json.loads(json_match.group())
                 predictions = data.get("predictions", [])
-                parsed = []
-                seen = set()
+                best: dict[str, float] = {}
                 for prediction in predictions:
                     category = prediction.get("category", "Unknown")
-                    if category not in self.categories or category in seen:
+                    if category not in self.categories:
                         continue
-                    parsed.append(
-                        (category, float(prediction.get("confidence", 0.5)))
-                    )
-                    seen.add(category)
+                    confidence = float(prediction.get("confidence", 0.5))
+                    if category not in best or confidence > best[category]:
+                        best[category] = confidence
+                parsed = list(best.items())
 
                 if parsed:
                     return sorted(parsed, key=lambda item: item[1], reverse=True)

--- a/src/evoprompt/agents/router_agent.py
+++ b/src/evoprompt/agents/router_agent.py
@@ -10,10 +10,10 @@ import json
 import re
 from typing import List, Tuple, Optional, Dict, Any
 
-from .base import RoutingResult
+from .base import BENIGN_CATEGORY, RoutingResult
 
 # Major categories aligned with CWE taxonomy
-MAJOR_CATEGORIES = ["Memory", "Injection", "Logic", "Input", "Crypto", "Benign"]
+MAJOR_CATEGORIES = ["Memory", "Injection", "Logic", "Input", "Crypto", BENIGN_CATEGORY]
 
 DEFAULT_ROUTER_PROMPT = """You are a security expert routing code to specialized vulnerability detectors.
 
@@ -108,7 +108,7 @@ class RouterAgent:
 
         evidence = []
         for category in self.categories:
-            if category == "Benign":
+            if category == BENIGN_CATEGORY:
                 continue
             samples = self.retriever.retrieve_from_category(
                 code, category, top_k=n_per_category
@@ -176,6 +176,6 @@ class RouterAgent:
 
         # Ensure we have at least one prediction
         if not scores:
-            scores = [("Benign", 0.5)]
+            scores = [(BENIGN_CATEGORY, 0.5)]
 
         return scores

--- a/src/evoprompt/strategies/mulvul_strategy.py
+++ b/src/evoprompt/strategies/mulvul_strategy.py
@@ -70,14 +70,26 @@ class MulVulStrategy:
         self.llm_client = llm_client
         self.config = config or {}
 
-        k = self.config.get("k", 3)
+        max_agents = self.config.get("max_agents", self.config.get("k", 3))
         parallel = self.config.get("parallel", True)
+        adaptive_agents = self.config.get("adaptive_agents", True)
 
         self.detector = MulVulDetector.create_default(
             llm_client=llm_client,
             retriever=self.config.get("retriever"),
-            k=k,
+            max_agents=max_agents,
             parallel=parallel,
+            adaptive=adaptive_agents,
+            min_agents=self.config.get("min_agents", 1),
+            routing_confidence_threshold=self.config.get(
+                "routing_confidence_threshold", 0.2
+            ),
+            routing_relative_threshold=self.config.get(
+                "routing_relative_threshold", 0.6
+            ),
+            benign_short_circuit_threshold=self.config.get(
+                "benign_short_circuit_threshold", 0.8
+            ),
         )
 
     # ------------------------------------------------------------------

--- a/tests/test_mulvul_detector.py
+++ b/tests/test_mulvul_detector.py
@@ -1,10 +1,5 @@
 """Tests for adaptive MulVul detector routing."""
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-
 from evoprompt.agents.base import (
     BENIGN_CATEGORY,
     UNKNOWN_CATEGORY,

--- a/tests/test_mulvul_detector.py
+++ b/tests/test_mulvul_detector.py
@@ -1,0 +1,178 @@
+"""Tests for adaptive MulVul detector routing."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from evoprompt.agents.base import DetectionResult, RoutingResult
+from evoprompt.agents.mulvul import MulVulDetector
+from evoprompt.agents.router_agent import RouterAgent
+
+
+class StubRouter:
+    """Deterministic router stub for MulVul tests."""
+
+    def __init__(self, categories):
+        self._routing_result = RoutingResult(
+            categories=categories,
+            evidence_used=[],
+            raw_response="router-response",
+        )
+
+    def route(self, code: str) -> RoutingResult:
+        return self._routing_result
+
+
+class StubDetector:
+    """Detector stub that records calls and returns a fixed result."""
+
+    def __init__(self, category: str, prediction: str, confidence: float):
+        self.category = category
+        self.prediction = prediction
+        self.confidence = confidence
+        self.calls = 0
+
+    def detect(self, code: str) -> DetectionResult:
+        self.calls += 1
+        return DetectionResult(
+            prediction=self.prediction,
+            confidence=self.confidence,
+            evidence=f"{self.category} evidence",
+            category=self.category,
+            cwe=self.prediction if self.prediction.startswith("CWE-") else "",
+            agent_id=f"detector_{self.category.lower()}",
+        )
+
+
+def _build_detectors():
+    return {
+        "Memory": StubDetector("Memory", "CWE-120", 0.91),
+        "Injection": StubDetector("Injection", "CWE-89", 0.72),
+        "Input": StubDetector("Input", "CWE-22", 0.61),
+        "Crypto": StubDetector("Crypto", "CWE-327", 0.44),
+    }
+
+
+def test_router_parse_response_sorts_and_filters_predictions():
+    router = RouterAgent(llm_client=object())
+    response = """
+    {
+      "predictions": [
+        {"category": "Injection", "confidence": 0.52},
+        {"category": "Memory", "confidence": 0.81},
+        {"category": "Unknown", "confidence": 0.99},
+        {"category": "Memory", "confidence": 0.33}
+      ]
+    }
+    """
+
+    parsed = router._parse_response(response)
+
+    assert parsed == [("Memory", 0.81), ("Injection", 0.52)]
+
+
+def test_adaptive_routing_selects_single_detector_for_confident_router():
+    detectors = _build_detectors()
+    detector = MulVulDetector(
+        router=StubRouter([
+            ("Memory", 0.92),
+            ("Injection", 0.40),
+            ("Input", 0.32),
+            ("Benign", 0.05),
+        ]),
+        detectors=detectors,
+        parallel=False,
+        max_agents=3,
+        adaptive=True,
+        routing_confidence_threshold=0.2,
+        routing_relative_threshold=0.6,
+    )
+
+    details = detector.detect_with_details("code sample")
+
+    assert details["routing"]["selected"] == [("Memory", 0.92)]
+    assert detectors["Memory"].calls == 1
+    assert detectors["Injection"].calls == 0
+    assert detectors["Input"].calls == 0
+
+
+def test_adaptive_routing_selects_multiple_detectors_when_router_is_uncertain():
+    detectors = _build_detectors()
+    detector = MulVulDetector(
+        router=StubRouter([
+            ("Memory", 0.51),
+            ("Injection", 0.46),
+            ("Input", 0.31),
+            ("Crypto", 0.18),
+            ("Benign", 0.07),
+        ]),
+        detectors=detectors,
+        parallel=False,
+        max_agents=3,
+        adaptive=True,
+        routing_confidence_threshold=0.2,
+        routing_relative_threshold=0.6,
+    )
+
+    details = detector.detect_with_details("code sample")
+
+    assert details["routing"]["selected"] == [
+        ("Memory", 0.51),
+        ("Injection", 0.46),
+        ("Input", 0.31),
+    ]
+    assert detectors["Memory"].calls == 1
+    assert detectors["Injection"].calls == 1
+    assert detectors["Input"].calls == 1
+    assert detectors["Crypto"].calls == 0
+
+
+def test_benign_short_circuit_skips_specialist_detectors():
+    detectors = _build_detectors()
+    detector = MulVulDetector(
+        router=StubRouter([
+            ("Benign", 0.88),
+            ("Memory", 0.42),
+            ("Injection", 0.19),
+        ]),
+        detectors=detectors,
+        parallel=False,
+        max_agents=3,
+        adaptive=True,
+        routing_relative_threshold=0.6,
+        benign_short_circuit_threshold=0.8,
+    )
+
+    result = detector.detect("code sample")
+
+    assert result.prediction == "Benign"
+    assert result.category == "Benign"
+    assert all(stub.calls == 0 for stub in detectors.values())
+
+
+def test_fixed_routing_preserves_max_agent_cap():
+    detectors = _build_detectors()
+    detector = MulVulDetector(
+        router=StubRouter([
+            ("Memory", 0.80),
+            ("Injection", 0.79),
+            ("Input", 0.78),
+            ("Crypto", 0.77),
+        ]),
+        detectors=detectors,
+        parallel=False,
+        max_agents=2,
+        adaptive=False,
+    )
+
+    details = detector.detect_with_details("code sample")
+
+    assert details["routing"]["selected"] == [
+        ("Memory", 0.80),
+        ("Injection", 0.79),
+    ]
+    assert detectors["Memory"].calls == 1
+    assert detectors["Injection"].calls == 1
+    assert detectors["Input"].calls == 0
+    assert detectors["Crypto"].calls == 0

--- a/tests/test_mulvul_detector.py
+++ b/tests/test_mulvul_detector.py
@@ -91,6 +91,11 @@ def test_adaptive_routing_selects_single_detector_for_confident_router():
 
     details = detector.detect_with_details("code sample")
 
+    assert details["routing"]["top_k"] == [
+        ("Memory", 0.92),
+        ("Injection", 0.40),
+        ("Input", 0.32),
+    ]
     assert details["routing"]["selected"] == [("Memory", 0.92)]
     assert detectors["Memory"].calls == 1
     assert detectors["Injection"].calls == 0
@@ -148,6 +153,46 @@ def test_benign_short_circuit_skips_specialist_detectors():
 
     assert result.prediction == "Benign"
     assert result.category == "Benign"
+    assert all(stub.calls == 0 for stub in detectors.values())
+
+
+def test_benign_high_confidence_but_competitive_vuln_does_not_short_circuit():
+    detectors = _build_detectors()
+    detector = MulVulDetector(
+        router=StubRouter([
+            ("Benign", 0.88),
+            ("Memory", 0.70),
+            ("Injection", 0.19),
+        ]),
+        detectors=detectors,
+        parallel=False,
+        max_agents=3,
+        adaptive=True,
+        routing_relative_threshold=0.6,
+        benign_short_circuit_threshold=0.8,
+    )
+
+    result = detector.detect("code sample")
+
+    assert detectors["Memory"].calls == 1
+    assert result.agent_id == "aggregator(detector_memory)"
+    assert result.category == "Memory"
+
+
+def test_unknown_when_router_has_no_supported_categories():
+    detectors = _build_detectors()
+    detector = MulVulDetector(
+        router=StubRouter([("UnsupportedCategory", 0.90)]),
+        detectors=detectors,
+        parallel=False,
+    )
+
+    result = detector.detect("code sample")
+
+    assert result.prediction == "Unknown"
+    assert result.confidence == 0.0
+    assert result.evidence == "Router did not return any supported detector category."
+    assert result.agent_id == "router_empty"
     assert all(stub.calls == 0 for stub in detectors.values())
 
 

--- a/tests/test_mulvul_detector.py
+++ b/tests/test_mulvul_detector.py
@@ -86,6 +86,27 @@ def test_router_parse_response_sorts_and_filters_predictions():
     assert parsed == [("Memory", 0.81), ("Injection", 0.52)]
 
 
+def test_router_parse_response_keeps_max_confidence_for_duplicates():
+    """When the LLM emits a low-confidence duplicate before a higher one,
+    the parser should retain the maximum confidence."""
+    llm_client = StubLLMClient(
+        """
+    {
+      "predictions": [
+        {"category": "Memory", "confidence": 0.33},
+        {"category": "Injection", "confidence": 0.52},
+        {"category": "Memory", "confidence": 0.81}
+      ]
+    }
+    """
+    )
+    router = RouterAgent(llm_client=llm_client)
+
+    parsed = router.route("int main() { return 0; }").categories
+
+    assert parsed == [("Memory", 0.81), ("Injection", 0.52)]
+
+
 def test_adaptive_routing_selects_single_detector_for_confident_router():
     detectors = _build_detectors()
     detector = MulVulDetector(

--- a/tests/test_mulvul_detector.py
+++ b/tests/test_mulvul_detector.py
@@ -1,13 +1,30 @@
 """Tests for adaptive MulVul detector routing."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from evoprompt.agents.base import DetectionResult, RoutingResult
+from evoprompt.agents.base import (
+    BENIGN_CATEGORY,
+    UNKNOWN_CATEGORY,
+    DetectionResult,
+    RoutingResult,
+)
 from evoprompt.agents.mulvul import MulVulDetector
 from evoprompt.agents.router_agent import RouterAgent
+
+
+class StubLLMClient:
+    """LLM stub returning a fixed router response."""
+
+    def __init__(self, response: str):
+        self.response = response
+        self.prompts = []
+
+    def generate(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return self.response
 
 
 class StubRouter:
@@ -55,8 +72,8 @@ def _build_detectors():
 
 
 def test_router_parse_response_sorts_and_filters_predictions():
-    router = RouterAgent(llm_client=object())
-    response = """
+    llm_client = StubLLMClient(
+        """
     {
       "predictions": [
         {"category": "Injection", "confidence": 0.52},
@@ -66,8 +83,10 @@ def test_router_parse_response_sorts_and_filters_predictions():
       ]
     }
     """
+    )
+    router = RouterAgent(llm_client=llm_client)
 
-    parsed = router._parse_response(response)
+    parsed = router.route("int main() { return 0; }").categories
 
     assert parsed == [("Memory", 0.81), ("Injection", 0.52)]
 
@@ -79,7 +98,7 @@ def test_adaptive_routing_selects_single_detector_for_confident_router():
             ("Memory", 0.92),
             ("Injection", 0.40),
             ("Input", 0.32),
-            ("Benign", 0.05),
+            (BENIGN_CATEGORY, 0.05),
         ]),
         detectors=detectors,
         parallel=False,
@@ -110,7 +129,7 @@ def test_adaptive_routing_selects_multiple_detectors_when_router_is_uncertain():
             ("Injection", 0.46),
             ("Input", 0.31),
             ("Crypto", 0.18),
-            ("Benign", 0.07),
+            (BENIGN_CATEGORY, 0.07),
         ]),
         detectors=detectors,
         parallel=False,
@@ -137,7 +156,7 @@ def test_benign_short_circuit_skips_specialist_detectors():
     detectors = _build_detectors()
     detector = MulVulDetector(
         router=StubRouter([
-            ("Benign", 0.88),
+            (BENIGN_CATEGORY, 0.88),
             ("Memory", 0.42),
             ("Injection", 0.19),
         ]),
@@ -151,8 +170,8 @@ def test_benign_short_circuit_skips_specialist_detectors():
 
     result = detector.detect("code sample")
 
-    assert result.prediction == "Benign"
-    assert result.category == "Benign"
+    assert result.prediction == BENIGN_CATEGORY
+    assert result.category == BENIGN_CATEGORY
     assert all(stub.calls == 0 for stub in detectors.values())
 
 
@@ -160,7 +179,7 @@ def test_benign_high_confidence_but_competitive_vuln_does_not_short_circuit():
     detectors = _build_detectors()
     detector = MulVulDetector(
         router=StubRouter([
-            ("Benign", 0.88),
+            (BENIGN_CATEGORY, 0.88),
             ("Memory", 0.70),
             ("Injection", 0.19),
         ]),
@@ -189,9 +208,10 @@ def test_unknown_when_router_has_no_supported_categories():
 
     result = detector.detect("code sample")
 
-    assert result.prediction == "Unknown"
+    assert result.prediction == UNKNOWN_CATEGORY
     assert result.confidence == 0.0
     assert result.evidence == "Router did not return any supported detector category."
+    assert result.category == UNKNOWN_CATEGORY
     assert result.agent_id == "router_empty"
     assert all(stub.calls == 0 for stub in detectors.values())
 


### PR DESCRIPTION
Summary:
- 将 MulVul 的固定 `Top-3` detector 调度改为基于 router 置信度的自适应 agent 数量。
- Router 改为返回排序后的类别列表；MulVul 根据相对/绝对阈值决定实际启动多少个 detector，并支持 Benign 高置信短路。
- 保留 `k` 作为向后兼容别名，同时在 demo 和两个评估脚本中新增/同步 `max_agents` 与 fixed 模式。
- 新增单测覆盖自适应单 agent、多 agent、Benign 短路和 fixed 兼容路径。

Verification:
- `uv run --no-sync pytest tests/test_mulvul_detector.py tests/test_multiagent_components.py -q`
- `uv run --no-sync python -m py_compile src/evoprompt/agents/base.py src/evoprompt/agents/router_agent.py src/evoprompt/agents/mulvul.py src/evoprompt/strategies/mulvul_strategy.py scripts/demo_mulvul.py scripts/run_mulvul_eval.py scripts/run_mulvul_cwe_eval.py tests/test_mulvul_detector.py`

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

让 MulVul 多代理漏洞检测器基于路由器（router）置信度自适应地选择要运行的专用代理，而不是使用固定的 top-k fan-out。

新功能：
- 在 MulVul 中基于路由器置信度添加自适应检测 fan-out，包括可配置的阈值、最小/最大代理数，以及“良性（benign）”的短路处理。
- 扩展 RouterAgent，使其返回排序且去重的类别列表，支持可选的候选上限控制，并改进对良性结果的处理。
- 在 MulVul 策略、演示（demo）和评估脚本中暴露 `max_agents` 以及自适应/固定路由选项，并提供向后兼容的 `k` 别名。
- 添加单元测试，覆盖路由器解析行为、自适应的单/多代理选择、良性短路处理、未知类别处理以及固定路由行为。

增强：
- 优化 MulVul 检测细节和原始响应中的路由元数据，加入排序后的类别、被选中的类别以及选中代理数量等信息。
- 通过为良性和未知类别引入共享常量，并泛化 `RoutingResult` 访问器，改进基础代理抽象。

测试：
- 为 MulVul 的自适应路由逻辑和 RouterAgent 响应解析引入全面测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the MulVul multi-agent vulnerability detector adaptively choose which specialist agents to run based on router confidence instead of a fixed top-k fan-out.

New Features:
- Add adaptive detector fan-out in MulVul based on router confidence, including configurable thresholds, minimum/maximum agents, and benign short-circuiting.
- Extend RouterAgent to return a ranked, deduplicated list of categories with optional candidate capping and improved benign handling.
- Expose max_agents and adaptive/fixed routing options in the MulVul strategy, demo, and evaluation scripts, with backward-compatible k aliases.
- Add unit tests covering router parsing behavior, adaptive single/multi-agent selection, benign short-circuiting, unknown-category handling, and fixed routing behavior.

Enhancements:
- Refine routing metadata in MulVul detection details and raw responses to include ranked and selected categories and selected agent counts.
- Improve base agent abstractions by introducing shared constants for benign and unknown categories and by generalizing RoutingResult accessors.

Tests:
- Introduce comprehensive tests for MulVul adaptive routing logic and RouterAgent response parsing.

</details>

</details>

</details>

</details>

</details>